### PR TITLE
Disclose TNER commercial-use requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Obscura are documented in this file.
 
+## Unreleased
+
+- Documented LDC's confirmation that commercial use of the optional TNER
+  checkpoint requires an LDC for-profit membership.
+- Added machine-readable asset licensing metadata plus preflight and
+  preparation notices for the affected `:balanced` and `:accurate` profiles.
+- Kept `:fast` dependency-light and unaffected by the TNER requirement.
+
 ## 0.1.0 - 2026-07-21
 
 Initial public release.

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ Use `:fast` when structured identifiers are sufficient:
 Obscura.analyze("Contact jane@example.com", profile: :fast)
 ```
 
-`:balanced` is the practical model-backed recommendation for noncommercial
-evaluation or deployments with the required LDC authorization. `:accurate` has
-the highest measured general accuracy, but its second model increases
-preparation, memory, and inference cost. Dataset-specific results and
-limitations are in the [benchmark status](docs/benchmark-status.md).
+`:balanced` is the practical model-backed recommendation when its external
+asset terms are acceptable for the deployment. `:accurate` has the highest
+measured general accuracy, but its second model increases preparation, memory,
+and inference cost. Dataset-specific results and limitations are in the
+[benchmark status](docs/benchmark-status.md).
 
 Model profiles require explicit reusable runtime preparation. Ordinary calls
 never download models:
@@ -167,11 +167,11 @@ the [profile guide](docs/profiles.md),
 [runtime diagnostics](docs/runtime-diagnostics.md).
 
 The model assets are third-party downloads that Obscura neither bundles nor
-licenses. LDC directly confirmed on 2026-07-22 that commercial use of the TNER
-checkpoint used by `:balanced` and `:accurate` requires an LDC for-profit
-membership. Obscura does not grant or verify that authorization. Use these
-profiles only for noncommercial evaluation or where the deployer has the
-required LDC authorization. See
+licenses. In direct correspondence on 2026-07-22, LDC confirmed that commercial
+use of `tner/roberta-large-ontonotes5`, used by `:balanced` and `:accurate`,
+requires an LDC for-profit membership. Obscura does not grant or verify that
+authorization, and noncommercial use remains subject to the applicable LDC and
+upstream terms. See
 [model asset licensing](docs/model-asset-licensing.md).
 
 Stable profile names have compatibility guarantees, but stability does not
@@ -463,7 +463,7 @@ schemas, struct guarantees, and the deprecation policy.
 | --- | --- |
 | Core text, structured, vault, LLM, Logger, Plug, and operator APIs | Stable |
 | `:fast` alias | Stable name and dependency-light contract |
-| `:balanced` and `:accurate` aliases | Stable implementation contracts; commercial TNER use requires LDC for-profit membership |
+| `:balanced` and `:accurate` aliases | Stable implementation contracts; commercial use of their OntoNotes-trained TNER checkpoint requires LDC for-profit membership |
 | Experimental profiles and low-level model adapters | Controlled evaluation without compatibility guarantees |
 | Evaluation, fixture, engine, registry, and model-math modules | Internal |
 

--- a/README.md
+++ b/README.md
@@ -125,10 +125,11 @@ Use `:fast` when structured identifiers are sufficient:
 Obscura.analyze("Contact jane@example.com", profile: :fast)
 ```
 
-`:balanced` is the practical model-backed recommendation. `:accurate` has the
-highest measured general accuracy, but its second model increases preparation,
-memory, and inference cost. Dataset-specific results and limitations are in the
-[benchmark status](docs/benchmark-status.md).
+`:balanced` is the practical model-backed recommendation for noncommercial
+evaluation or deployments with the required LDC authorization. `:accurate` has
+the highest measured general accuracy, but its second model increases
+preparation, memory, and inference cost. Dataset-specific results and
+limitations are in the [benchmark status](docs/benchmark-status.md).
 
 Model profiles require explicit reusable runtime preparation. Ordinary calls
 never download models:
@@ -166,9 +167,12 @@ the [profile guide](docs/profiles.md),
 [runtime diagnostics](docs/runtime-diagnostics.md).
 
 The model assets are third-party downloads that Obscura neither bundles nor
-licenses. Deployers must review whether each selected asset and use is
-permitted. The TNER checkpoint used by `:balanced` and `:accurate` has an
-unresolved license. See [model asset licensing](docs/model-asset-licensing.md).
+licenses. LDC directly confirmed on 2026-07-22 that commercial use of the TNER
+checkpoint used by `:balanced` and `:accurate` requires an LDC for-profit
+membership. Obscura does not grant or verify that authorization. Use these
+profiles only for noncommercial evaluation or where the deployer has the
+required LDC authorization. See
+[model asset licensing](docs/model-asset-licensing.md).
 
 Stable profile names have compatibility guarantees, but stability does not
 mean universal production readiness or regulatory compliance. Additional
@@ -459,7 +463,7 @@ schemas, struct guarantees, and the deprecation policy.
 | --- | --- |
 | Core text, structured, vault, LLM, Logger, Plug, and operator APIs | Stable |
 | `:fast` alias | Stable name and dependency-light contract |
-| `:balanced` and `:accurate` aliases | Stable implementation contracts; optional assets require deployer licensing review |
+| `:balanced` and `:accurate` aliases | Stable implementation contracts; commercial TNER use requires LDC for-profit membership |
 | Experimental profiles and low-level model adapters | Controlled evaluation without compatibility guarantees |
 | Evaluation, fixture, engine, registry, and model-math modules | Internal |
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -33,3 +33,13 @@ The Presidio-Research dataset snapshots committed under
 `eval/datasets/presidio_research/` are excluded from the Hex package and carry
 their own license and notice files in that directory. Optional model weights,
 tokenizers, caches, and exported ONNX assets are not bundled with Obscura.
+
+## TNER OntoNotes Model
+
+The optional `tner/roberta-large-ontonotes5` checkpoint used by `:balanced`
+and `:accurate` is not bundled, distributed, sublicensed, or licensed by
+Obscura. LDC directly confirmed on 2026-07-22 that commercial use requires an
+LDC for-profit membership under the applicable OntoNotes terms. Obscura does
+not grant or verify that authorization. LDC did not conclusively answer the
+separate checkpoint-redistribution question. See
+`docs/model-asset-licensing.md` before preparing this external asset.

--- a/docs/authoritative-presidio-comparison-report.md
+++ b/docs/authoritative-presidio-comparison-report.md
@@ -162,11 +162,12 @@ generated heldout, `0.1212` on synth, and `0.0719` on Nemotron.
 
 `:fast`, `:balanced`, and `:accurate` have stable Obscura profile contracts.
 `:accurate` has the best measured general F1 under this protocol, while
-`:balanced` remains the practical one-model recommendation. The optional TNER
-checkpoint is neither bundled nor licensed by Obscura; deployers remain
-responsible for establishing applicable asset rights. The `:openmed_pii` row is
-an authoritative measurement of an experimental alias, not evidence that it
-belongs in the stable product surface.
+`:balanced` remains the practical one-model recommendation for noncommercial
+evaluation or LDC-authorized deployments. The optional TNER checkpoint is
+neither bundled nor licensed by Obscura. LDC directly confirmed on 2026-07-22
+that commercial use requires an LDC for-profit membership. The `:openmed_pii`
+row is an authoritative measurement of an experimental alias, not evidence
+that it belongs in the stable product surface.
 
 The implementation is not complete Presidio parity. Presidio still wins some
 entity-specific comparisons, model-backed Obscura profiles require optional

--- a/docs/authoritative-presidio-comparison-report.md
+++ b/docs/authoritative-presidio-comparison-report.md
@@ -162,12 +162,12 @@ generated heldout, `0.1212` on synth, and `0.0719` on Nemotron.
 
 `:fast`, `:balanced`, and `:accurate` have stable Obscura profile contracts.
 `:accurate` has the best measured general F1 under this protocol, while
-`:balanced` remains the practical one-model recommendation for noncommercial
-evaluation or LDC-authorized deployments. The optional TNER checkpoint is
-neither bundled nor licensed by Obscura. LDC directly confirmed on 2026-07-22
-that commercial use requires an LDC for-profit membership. The `:openmed_pii`
-row is an authoritative measurement of an experimental alias, not evidence
-that it belongs in the stable product surface.
+`:balanced` remains the practical one-model recommendation when its external
+asset terms are acceptable. The optional `tner/roberta-large-ontonotes5`
+checkpoint is neither bundled nor licensed by Obscura. In direct correspondence
+on 2026-07-22, LDC confirmed that its commercial use requires an LDC for-profit
+membership. The `:openmed_pii` row is an authoritative measurement of an
+experimental alias, not evidence that it belongs in the stable product surface.
 
 The implementation is not complete Presidio parity. Presidio still wins some
 entity-specific comparisons, model-backed Obscura profiles require optional

--- a/docs/benchmark-status.md
+++ b/docs/benchmark-status.md
@@ -39,11 +39,12 @@ made.
 - `:fast` is the high-precision, low-latency structured PII choice. Its recall
   is intentionally limited.
 - `:accurate` has the highest measured general F1 on all three shared datasets.
-  Its stable profile contract uses two large models. Commercial use requires an
-  LDC for-profit membership because TNER is its primary model.
-- `:balanced` remains the practical model-backed recommendation for
-  noncommercial evaluation or LDC-authorized deployments. Its F1 is slightly
-  lower, but it uses one model and has materially lower latency.
+  Its stable profile contract uses two large models. Commercial use of its
+  primary `tner/roberta-large-ontonotes5` asset requires an LDC for-profit
+  membership.
+- `:balanced` remains the practical model-backed recommendation when its
+  external asset terms are acceptable. Its F1 is slightly lower, but it uses
+  one model and has materially lower latency.
 - `:hybrid_gliner_urchade` is the public experimental CPU-only general NER
   alternative. Its reproducible adapter and clearer Apache-2.0 provenance chain
   support that scoped recommendation, but its lower F1 prevents replacing

--- a/docs/benchmark-status.md
+++ b/docs/benchmark-status.md
@@ -39,10 +39,11 @@ made.
 - `:fast` is the high-precision, low-latency structured PII choice. Its recall
   is intentionally limited.
 - `:accurate` has the highest measured general F1 on all three shared datasets.
-  Its stable profile contract uses two large models and inherits the unresolved
-  TNER checkpoint license, which remains a deployer asset decision.
-- `:balanced` remains the practical model-backed recommendation. Its F1 is
-  slightly lower, but it uses one model and has materially lower latency.
+  Its stable profile contract uses two large models. Commercial use requires an
+  LDC for-profit membership because TNER is its primary model.
+- `:balanced` remains the practical model-backed recommendation for
+  noncommercial evaluation or LDC-authorized deployments. Its F1 is slightly
+  lower, but it uses one model and has materially lower latency.
 - `:hybrid_gliner_urchade` is the public experimental CPU-only general NER
   alternative. Its reproducible adapter and clearer Apache-2.0 provenance chain
   support that scoped recommendation, but its lower F1 prevents replacing

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -52,11 +52,10 @@ surface.
 
 - No model weights or external datasets ship in the Hex package.
 - Analyzer/redaction calls never download models. Preparation is explicit.
-- LDC directly confirmed on 2026-07-22 that commercial use of the TNER
-  checkpoint requires an LDC for-profit membership. Stable profile status does
-  not grant or verify that authorization. Use `:balanced` and `:accurate` only
-  for noncommercial evaluation or deployments with the required LDC
-  authorization.
+- In direct correspondence on 2026-07-22, LDC confirmed that commercial use of
+  `tner/roberta-large-ontonotes5` requires an LDC for-profit membership. Stable
+  profile status does not grant or verify that authorization. Noncommercial use
+  remains subject to the applicable LDC and upstream terms.
 - The Apache-licensed Urchade GLiNER candidate has reproducible native Ortex
   support, but exact F1 is lower than `:balanced` on all three authoritative
   datasets. The Obscura Ortex fork can verify CoreML provider assignment, but

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -52,9 +52,11 @@ surface.
 
 - No model weights or external datasets ship in the Hex package.
 - Analyzer/redaction calls never download models. Preparation is explicit.
-- TNER license status is not established by Obscura. Stable profile status does
-  not license the optional checkpoint; deployers must review and accept all
-  applicable asset terms.
+- LDC directly confirmed on 2026-07-22 that commercial use of the TNER
+  checkpoint requires an LDC for-profit membership. Stable profile status does
+  not grant or verify that authorization. Use `:balanced` and `:accurate` only
+  for noncommercial evaluation or deployments with the required LDC
+  authorization.
 - The Apache-licensed Urchade GLiNER candidate has reproducible native Ortex
   support, but exact F1 is lower than `:balanced` on all three authoritative
   datasets. The Obscura Ortex fork can verify CoreML provider assignment, but

--- a/docs/model-asset-licensing.md
+++ b/docs/model-asset-licensing.md
@@ -93,12 +93,12 @@ revisions where available, and never bundles them in the Hex package.
 ### Stable Profile Consequences
 
 The `:balanced` and `:accurate` names, option schemas, preparation behavior,
-and result contracts are stable Obscura APIs. Commercial use of their default
-TNER asset requires an LDC for-profit membership according to direct LDC
-confirmation dated 2026-07-22. Stable therefore means API compatibility and
-measured technical behavior, not permission to use a checkpoint. These
-profiles are appropriate for noncommercial evaluation or deployments with the
-required LDC authorization.
+and result contracts are stable Obscura APIs. In direct correspondence dated
+2026-07-22, LDC confirmed that commercial use of their default
+`tner/roberta-large-ontonotes5` asset requires an LDC for-profit membership.
+Stable therefore means API compatibility and measured technical behavior, not
+permission to use a checkpoint. Noncommercial use remains subject to the
+applicable LDC and upstream terms.
 
 `:accurate` adds the Jean-Baptiste model. Its model and base-model metadata are
 MIT, but users must still make their own CoNLL-2003 provenance decision.
@@ -124,8 +124,9 @@ Before preparing an external model, deployers must:
    substituted model or converted checkpoint.
 
 For `tner/roberta-large-ontonotes5`, commercial deployers must additionally
-document the required LDC for-profit membership. Obscura cannot verify
-membership or confer checkpoint rights.
+obtain and document the required LDC for-profit membership. Obscura cannot
+verify membership or confer checkpoint rights, and membership does not resolve
+the unanswered checkpoint-redistribution question on Obscura's behalf.
 
 `Obscura.Profile.preflight/2` reports third-party asset warnings. Passing
 preflight proves runtime readiness only; it does not prove legal authorization,

--- a/docs/model-asset-licensing.md
+++ b/docs/model-asset-licensing.md
@@ -1,7 +1,7 @@
 # Third-Party Dependency And Model Asset Review
 
 This document records the release licensing review for Obscura as of
-2026-07-21. It is an engineering inventory and release decision, not legal
+2026-07-22. It is an engineering inventory and release decision, not legal
 advice. A deployer remains responsible for determining whether a dependency,
 model, tokenizer, dataset, or generated output is permitted for its use.
 
@@ -85,7 +85,7 @@ revisions where available, and never bundles them in the Hex package.
 
 | Asset | Reviewed chain | Decision |
 | --- | --- | --- |
-| `tner/roberta-large-ontonotes5` at `0bce50f7...` | Checkpoint has no license metadata; TNER code is MIT; dataset card says `other`; OntoNotes is governed by an LDC agreement | **Unresolved external asset.** Not approved for redistribution by Obscura. Deployers must obtain and document authorization. |
+| `tner/roberta-large-ontonotes5` at `0bce50f7...` | Checkpoint has no license metadata; TNER code is MIT; dataset card says `other`; OntoNotes is governed by an LDC agreement | **Commercial use requires LDC for-profit membership.** LDC directly confirmed this requirement on 2026-07-22. Obscura does not grant or verify authorization and does not redistribute the checkpoint. LDC did not conclusively answer the separate checkpoint-redistribution question. |
 | `Jean-Baptiste/roberta-large-ner-english` at `8f3abc1e...` | Checkpoint MIT; `FacebookAI/roberta-large` tokenizer/base at `722cf37b...` MIT; trained on CoNLL-2003 | **Conditional deployer review.** Model/base grants are permissive, but training-data rights are not granted by Obscura. |
 | `OpenMed/privacy-filter-nemotron-v2` at reviewed revision `96824732...` | Checkpoint declares `license: other`; base `openai/privacy-filter` is Apache-2.0; Nemotron data is CC-BY-4.0; Gretel data is Apache-2.0; AI4Privacy data identifies CC-BY-4.0 | **Unresolved external asset.** The permissive base/data chain does not replace a checkpoint license grant. Keep experimental and do not redistribute. |
 | `urchade/gliner_multi_pii-v1` at `1fcf13e8...` | Checkpoint Apache-2.0; `gliner_multi-v2.1` Apache-2.0; synthetic PII dataset Apache-2.0; `microsoft/mdeberta-v3-base` tokenizer/encoder MIT | **Permissive chain documented.** Experimental status remains based on product quality and exported-asset support, not an identified license blocker. |
@@ -93,9 +93,12 @@ revisions where available, and never bundles them in the Hex package.
 ### Stable Profile Consequences
 
 The `:balanced` and `:accurate` names, option schemas, preparation behavior,
-and result contracts are stable Obscura APIs. Their default TNER asset is not
-license-cleared by Obscura. Stable therefore means API compatibility and
-measured technical behavior, not permission to use a checkpoint.
+and result contracts are stable Obscura APIs. Commercial use of their default
+TNER asset requires an LDC for-profit membership according to direct LDC
+confirmation dated 2026-07-22. Stable therefore means API compatibility and
+measured technical behavior, not permission to use a checkpoint. These
+profiles are appropriate for noncommercial evaluation or deployments with the
+required LDC authorization.
 
 `:accurate` adds the Jean-Baptiste model. Its model and base-model metadata are
 MIT, but users must still make their own CoNLL-2003 provenance decision.
@@ -120,6 +123,10 @@ Before preparing an external model, deployers must:
 6. Re-run accuracy, privacy, memory, latency, and failure validation for any
    substituted model or converted checkpoint.
 
+For `tner/roberta-large-ontonotes5`, commercial deployers must additionally
+document the required LDC for-profit membership. Obscura cannot verify
+membership or confer checkpoint rights.
+
 `Obscura.Profile.preflight/2` reports third-party asset warnings. Passing
 preflight proves runtime readiness only; it does not prove legal authorization,
 regulatory compliance, or universal model quality.
@@ -138,6 +145,8 @@ new revision under the same profile name.
 - [TNER checkpoint](https://huggingface.co/tner/roberta-large-ontonotes5)
 - [TNER dataset card](https://huggingface.co/datasets/tner/ontonotes5)
 - [OntoNotes Release 5.0](https://catalog.ldc.upenn.edu/LDC2013T19)
+- [LDC User Agreement for Non-Members](https://catalog.ldc.upenn.edu/license/ldc-non-members-agreement.pdf)
+- [LDC For-Profit Membership Agreement](https://catalog.ldc.upenn.edu/license/ldc-for-profit-membership.pdf)
 - [Jean-Baptiste checkpoint](https://huggingface.co/Jean-Baptiste/roberta-large-ner-english)
 - [FacebookAI RoBERTa large](https://huggingface.co/FacebookAI/roberta-large)
 - [OpenMed Privacy Filter Nemotron v2](https://huggingface.co/OpenMed/privacy-filter-nemotron-v2)

--- a/docs/model-backed-recognition.md
+++ b/docs/model-backed-recognition.md
@@ -8,7 +8,9 @@ model profile.
 
 Applications should use the public profile boundary:
 
-- `:balanced` uses one TNER model and is the practical general recommendation.
+- `:balanced` uses one TNER model and is the practical general recommendation
+  for noncommercial evaluation or deployments with the required LDC
+  authorization.
 - `:accurate` adds conditional location recovery and has the highest measured
   general F1.
 - `:hybrid_gliner_urchade` is an experimental CPU-only GLiNER option.
@@ -134,8 +136,10 @@ the primary model returns no accepted location. The stable cascade policy is:
 ]
 ```
 
-These third-party checkpoints are not bundled or licensed by Obscura. Review
-`model-asset-licensing.md` before deployment.
+These third-party checkpoints are not bundled or licensed by Obscura. LDC
+directly confirmed on 2026-07-22 that commercial use of the TNER checkpoint
+requires an LDC for-profit membership. Obscura does not grant or verify that
+authorization. Review `model-asset-licensing.md` before deployment.
 
 ## Model Policy
 

--- a/docs/model-backed-recognition.md
+++ b/docs/model-backed-recognition.md
@@ -9,8 +9,7 @@ model profile.
 Applications should use the public profile boundary:
 
 - `:balanced` uses one TNER model and is the practical general recommendation
-  for noncommercial evaluation or deployments with the required LDC
-  authorization.
+  when its external asset terms are acceptable for the deployment.
 - `:accurate` adds conditional location recovery and has the highest measured
   general F1.
 - `:hybrid_gliner_urchade` is an experimental CPU-only GLiNER option.
@@ -136,10 +135,11 @@ the primary model returns no accepted location. The stable cascade policy is:
 ]
 ```
 
-These third-party checkpoints are not bundled or licensed by Obscura. LDC
-directly confirmed on 2026-07-22 that commercial use of the TNER checkpoint
-requires an LDC for-profit membership. Obscura does not grant or verify that
-authorization. Review `model-asset-licensing.md` before deployment.
+These third-party checkpoints are not bundled or licensed by Obscura. In direct
+correspondence on 2026-07-22, LDC confirmed that commercial use of
+`tner/roberta-large-ontonotes5` requires an LDC for-profit membership. Obscura
+does not grant or verify that authorization. Review
+`model-asset-licensing.md` before deployment.
 
 ## Model Policy
 

--- a/docs/optional-dependencies-and-assets.md
+++ b/docs/optional-dependencies-and-assets.md
@@ -19,8 +19,8 @@ the manifests contain no local absolute paths or obvious credential material.
 | Profile | Stability | Base behavior | Required optional dependencies | Assets | Preferred development backend |
 | --- | --- | --- | --- | --- | --- |
 | `:fast` | stable | Deterministic structured PII | None | None | BEAM |
-| `:balanced` | stable, external assets require deployer review | Deterministic plus TNER NER | `nx`, `bumblebee` | TNER model and tokenizer | Emily on Apple Silicon; EXLA where supported |
-| `:accurate` | stable, external assets require deployer review | Deterministic plus output-aware TNER/Jean location cascade | `nx`, `bumblebee` | Two models and two tokenizers | Emily on Apple Silicon; EXLA where supported |
+| `:balanced` | stable; commercial TNER use requires LDC membership | Deterministic plus TNER NER | `nx`, `bumblebee` | TNER model and tokenizer | Emily on Apple Silicon; EXLA where supported |
+| `:accurate` | stable; commercial TNER use requires LDC membership | Deterministic plus output-aware TNER/Jean location cascade | `nx`, `bumblebee` | Two models and two tokenizers | Emily on Apple Silicon; EXLA where supported |
 | `:hybrid_gliner_urchade` | experimental | Deterministic plus Urchade GLiNER | `ortex`, `tokenizers` | Pinned local ONNX, tokenizer, and config export | Ortex CPU |
 | `:openmed_pii` | experimental | Native model-only OpenMed/Nemotron PII | `nx`, `safetensors` | Validated Privacy Filter checkpoint | Explicitly selected Binary, EXLA, or Emily |
 
@@ -169,8 +169,9 @@ not build it inside every request.
 `allow_download` defaults to `false`. Without it, remote repositories are
 opened with Bumblebee offline mode and only complete cached assets may be used.
 `offline: true` always forbids network access, even if download authorization
-was also passed. This separation makes accepting third-party terms and
-performing network I/O an explicit deployment action.
+was also passed. `allow_download` authorizes network I/O only; it does not
+accept third-party terms or establish commercial-use authorization. Review the
+reported asset licensing metadata as a separate deployment decision.
 
 Use the preparation task to populate a cache with structured progress:
 
@@ -182,6 +183,11 @@ mix obscura.profile.prepare \
   --timeout 1800000 \
   --inactivity-timeout 300000
 ```
+
+For model-backed profiles, preparation emits an `asset_license_notice` before
+the preparation-started event whenever Obscura knows that a model has a
+specific commercial-use requirement. Human-readable task output prints the
+notice directly; `--json` includes the same fields as structured progress.
 
 The effective cache directory follows explicit repository `cache_dir`, then
 `BUMBLEBEE_CACHE_DIR`, then the operating-system Bumblebee cache location.
@@ -228,11 +234,14 @@ both resources up front to keep request handling network-free and reusable.
   backend/runtime memory
 - Used by: stable `:balanced` and `:accurate`
 - Adapter: Bumblebee token classification
-- License status: not established by Obscura; verify upstream terms
+- Commercial use: requires an LDC for-profit membership, as directly confirmed
+  by LDC on 2026-07-22
 
-The profile integration is stable, but Obscura does not distribute or license
-the checkpoint. Deployers must establish whether their selected assets and use
-are permitted. See `docs/model-asset-licensing.md`.
+The profile integration is stable, but Obscura does not bundle, distribute,
+sublicense, or license the checkpoint and cannot verify LDC membership. Use it
+only for noncommercial evaluation or with the required LDC authorization. LDC
+did not conclusively answer whether the checkpoint publisher was authorized to
+redistribute the trained weights. See `docs/model-asset-licensing.md`.
 
 ### Urchade GLiNER Multi PII
 

--- a/docs/optional-dependencies-and-assets.md
+++ b/docs/optional-dependencies-and-assets.md
@@ -19,8 +19,8 @@ the manifests contain no local absolute paths or obvious credential material.
 | Profile | Stability | Base behavior | Required optional dependencies | Assets | Preferred development backend |
 | --- | --- | --- | --- | --- | --- |
 | `:fast` | stable | Deterministic structured PII | None | None | BEAM |
-| `:balanced` | stable; commercial TNER use requires LDC membership | Deterministic plus TNER NER | `nx`, `bumblebee` | TNER model and tokenizer | Emily on Apple Silicon; EXLA where supported |
-| `:accurate` | stable; commercial TNER use requires LDC membership | Deterministic plus output-aware TNER/Jean location cascade | `nx`, `bumblebee` | Two models and two tokenizers | Emily on Apple Silicon; EXLA where supported |
+| `:balanced` | stable; commercial use of its OntoNotes-trained asset requires LDC membership | Deterministic plus TNER NER | `nx`, `bumblebee` | TNER model and tokenizer | Emily on Apple Silicon; EXLA where supported |
+| `:accurate` | stable; commercial use of its OntoNotes-trained asset requires LDC membership | Deterministic plus output-aware TNER/Jean location cascade | `nx`, `bumblebee` | Two models and two tokenizers | Emily on Apple Silicon; EXLA where supported |
 | `:hybrid_gliner_urchade` | experimental | Deterministic plus Urchade GLiNER | `ortex`, `tokenizers` | Pinned local ONNX, tokenizer, and config export | Ortex CPU |
 | `:openmed_pii` | experimental | Native model-only OpenMed/Nemotron PII | `nx`, `safetensors` | Validated Privacy Filter checkpoint | Explicitly selected Binary, EXLA, or Emily |
 
@@ -238,10 +238,10 @@ both resources up front to keep request handling network-free and reusable.
   by LDC on 2026-07-22
 
 The profile integration is stable, but Obscura does not bundle, distribute,
-sublicense, or license the checkpoint and cannot verify LDC membership. Use it
-only for noncommercial evaluation or with the required LDC authorization. LDC
-did not conclusively answer whether the checkpoint publisher was authorized to
-redistribute the trained weights. See `docs/model-asset-licensing.md`.
+sublicense, or license the checkpoint and cannot verify LDC membership.
+Noncommercial use remains subject to the applicable LDC and upstream terms.
+LDC did not conclusively answer whether the checkpoint publisher was authorized
+to redistribute the trained weights. See `docs/model-asset-licensing.md`.
 
 ### Urchade GLiNER Multi PII
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -8,16 +8,17 @@ experimental and available for controlled evaluation.
 | `:fast` | stable | `:deterministic_plus` | Structured and context-labeled PII with high precision | Dependency-light BEAM execution |
 | `:balanced` | stable | `:hybrid_ner_tner_conservative` | General text needing person, location, and organization NER | One TNER model |
 | `:accurate` | stable | `:hybrid_ner_tner_jean_location_cascade` | Highest measured general accuracy with conditional location recovery | Two GPU-oriented NER models |
-| `:hybrid_gliner_urchade` | experimental | `:hybrid_gliner_urchade` | CPU-only general PII/NER without the TNER commercial-use requirement | One Ortex CPU model plus deterministic recognizers |
+| `:hybrid_gliner_urchade` | experimental | `:hybrid_gliner_urchade` | CPU-only general PII/NER without the OntoNotes-trained TNER asset | One Ortex CPU model plus deterministic recognizers |
 | `:openmed_pii` | experimental | `:privacy_filter_native` | OpenMed/Nemotron-style PII evaluation | One high-cost native model |
 
 `:accurate` currently has the best exact-span F1 on all three shared
 eight-entity datasets. `:balanced` remains the practical model-backed
-recommendation for noncommercial evaluation or LDC-authorized deployments
-because it uses one model and has lower latency. Their Obscura contracts are
-stable, but LDC directly confirmed on 2026-07-22 that commercial use of the
-TNER checkpoint requires an LDC for-profit membership. Obscura does not grant
-or verify that authorization. See `model-asset-licensing.md`.
+recommendation when its external asset terms are acceptable because it uses
+one model and has lower latency. Their Obscura contracts are stable, but in
+direct correspondence on 2026-07-22, LDC confirmed that commercial use of
+`tner/roberta-large-ontonotes5` requires an LDC for-profit membership. Obscura
+does not grant or verify that authorization. Noncommercial use remains subject
+to the applicable LDC and upstream terms. See `model-asset-licensing.md`.
 Measured accuracy does not establish universal accuracy, regulatory
 compliance, or suitability for every deployment.
 
@@ -56,8 +57,8 @@ controlled application startup:
 
 Obscura does not prepare or download this model from an analyzer call. The
 host application must include Nx, Bumblebee, and its chosen backend.
-Commercial use requires an LDC for-profit membership; use this profile only for
-noncommercial evaluation or with the required LDC authorization.
+Commercial use of `tner/roberta-large-ontonotes5` requires an LDC for-profit
+membership. Other uses remain subject to the applicable LDC and upstream terms.
 
 ## Accurate
 
@@ -66,8 +67,8 @@ noncommercial evaluation or with the required LDC authorization.
 `FacebookAI/roberta-large` tokenizer fallback only when TNER returns no
 accepted location.
 
-Because TNER remains the primary model, the same LDC commercial-use requirement
-applies to `:accurate`.
+Because `tner/roberta-large-ontonotes5` remains the primary model, the same
+checkpoint-specific LDC commercial-use requirement applies to `:accurate`.
 
 ```elixir
 {:ok, runtime} =
@@ -119,8 +120,8 @@ Prepare its pinned, locally exported ONNX/tokenizer/config bundle explicitly:
 ```
 
 This is the publicly recommended experimental CPU-only general NER option when
-an accelerator is unavailable or the TNER commercial-use requirement prevents
-using `:balanced`. It is not the accuracy leader. Its exact F1 was `0.7209`,
+an accelerator is unavailable or the terms of the OntoNotes-trained TNER asset
+prevent using `:balanced`. It is not the accuracy leader. Its exact F1 was `0.7209`,
 `0.6843`, and `0.4855` on the three shared datasets, compared with `0.7878`,
 `0.8388`, and `0.6954` for `:balanced`. Adapter parity passed, but the model
 produced materially weaker person/location quality and more false positives.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -8,15 +8,16 @@ experimental and available for controlled evaluation.
 | `:fast` | stable | `:deterministic_plus` | Structured and context-labeled PII with high precision | Dependency-light BEAM execution |
 | `:balanced` | stable | `:hybrid_ner_tner_conservative` | General text needing person, location, and organization NER | One TNER model |
 | `:accurate` | stable | `:hybrid_ner_tner_jean_location_cascade` | Highest measured general accuracy with conditional location recovery | Two GPU-oriented NER models |
-| `:hybrid_gliner_urchade` | experimental | `:hybrid_gliner_urchade` | CPU-only general PII/NER where GPU use or TNER licensing is unsuitable | One Ortex CPU model plus deterministic recognizers |
+| `:hybrid_gliner_urchade` | experimental | `:hybrid_gliner_urchade` | CPU-only general PII/NER without the TNER commercial-use requirement | One Ortex CPU model plus deterministic recognizers |
 | `:openmed_pii` | experimental | `:privacy_filter_native` | OpenMed/Nemotron-style PII evaluation | One high-cost native model |
 
 `:accurate` currently has the best exact-span F1 on all three shared
 eight-entity datasets. `:balanced` remains the practical model-backed
-recommendation because it uses one model and has lower latency. Their Obscura
-contracts are stable, but the optional TNER checkpoint is neither bundled nor
-licensed by Obscura. Deployers must review and accept the applicable asset
-terms. See `model-asset-licensing.md`.
+recommendation for noncommercial evaluation or LDC-authorized deployments
+because it uses one model and has lower latency. Their Obscura contracts are
+stable, but LDC directly confirmed on 2026-07-22 that commercial use of the
+TNER checkpoint requires an LDC for-profit membership. Obscura does not grant
+or verify that authorization. See `model-asset-licensing.md`.
 Measured accuracy does not establish universal accuracy, regulatory
 compliance, or suitability for every deployment.
 
@@ -55,6 +56,8 @@ controlled application startup:
 
 Obscura does not prepare or download this model from an analyzer call. The
 host application must include Nx, Bumblebee, and its chosen backend.
+Commercial use requires an LDC for-profit membership; use this profile only for
+noncommercial evaluation or with the required LDC authorization.
 
 ## Accurate
 
@@ -62,6 +65,9 @@ host application must include Nx, Bumblebee, and its chosen backend.
 `Jean-Baptiste/roberta-large-ner-english` with the
 `FacebookAI/roberta-large` tokenizer fallback only when TNER returns no
 accepted location.
+
+Because TNER remains the primary model, the same LDC commercial-use requirement
+applies to `:accurate`.
 
 ```elixir
 {:ok, runtime} =
@@ -113,8 +119,8 @@ Prepare its pinned, locally exported ONNX/tokenizer/config bundle explicitly:
 ```
 
 This is the publicly recommended experimental CPU-only general NER option when
-an accelerator is unavailable or the unresolved TNER checkpoint license blocks
-`:balanced`. It is not the accuracy leader. Its exact F1 was `0.7209`,
+an accelerator is unavailable or the TNER commercial-use requirement prevents
+using `:balanced`. It is not the accuracy leader. Its exact F1 was `0.7209`,
 `0.6843`, and `0.4855` on the three shared datasets, compared with `0.7878`,
 `0.8388`, and `0.6954` for `:balanced`. Adapter parity passed, but the model
 produced materially weaker person/location quality and more false positives.

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -77,7 +77,9 @@ promise:
 The `:balanced` and `:accurate` names, requirements, behavior, and preparation
 contracts are stable under the `0.1.x` compatibility promise. Their optional
 third-party model assets are not bundled or licensed by Obscura; stable API
-classification is not a grant of checkpoint rights. See
+classification is not a grant of checkpoint rights. LDC directly confirmed on
+2026-07-22 that commercial use of their TNER checkpoint requires an LDC
+for-profit membership. See
 `docs/model-asset-licensing.md`.
 
 ## Experimental Profile Contracts
@@ -190,8 +192,9 @@ progress subscriptions. Subscriber message payloads and progress maps are
 additive; applications should match only the documented event/status keys they
 consume.
 
-Model licenses are not granted by Obscura. TNER and OpenMed require independent
-license review, as documented in `docs/known-limitations.md`.
+Model licenses are not granted by Obscura. Commercial TNER use requires LDC
+for-profit membership; OpenMed still requires independent license review, as
+documented in `docs/known-limitations.md`.
 
 The experimental product aliases are:
 

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -77,9 +77,9 @@ promise:
 The `:balanced` and `:accurate` names, requirements, behavior, and preparation
 contracts are stable under the `0.1.x` compatibility promise. Their optional
 third-party model assets are not bundled or licensed by Obscura; stable API
-classification is not a grant of checkpoint rights. LDC directly confirmed on
-2026-07-22 that commercial use of their TNER checkpoint requires an LDC
-for-profit membership. See
+classification is not a grant of checkpoint rights. In direct correspondence
+on 2026-07-22, LDC confirmed that commercial use of
+`tner/roberta-large-ontonotes5` requires an LDC for-profit membership. See
 `docs/model-asset-licensing.md`.
 
 ## Experimental Profile Contracts
@@ -192,9 +192,10 @@ progress subscriptions. Subscriber message payloads and progress maps are
 additive; applications should match only the documented event/status keys they
 consume.
 
-Model licenses are not granted by Obscura. Commercial TNER use requires LDC
-for-profit membership; OpenMed still requires independent license review, as
-documented in `docs/known-limitations.md`.
+Model licenses are not granted by Obscura. Commercial use of
+`tner/roberta-large-ontonotes5` requires LDC for-profit membership; OpenMed
+still requires independent license review, as documented in
+`docs/known-limitations.md`.
 
 The experimental product aliases are:
 

--- a/lib/mix/tasks/obscura.profile.prepare.ex
+++ b/lib/mix/tasks/obscura.profile.prepare.ex
@@ -11,6 +11,10 @@ defmodule Mix.Tasks.Obscura.Profile.Prepare do
   elapsed time, and final readiness. JSON mode emits one object per line and
   disables Bumblebee's terminal progress bar.
 
+  Before preparing an asset with a known commercial-use requirement, the task
+  emits an `asset_license_notice`. `--allow-download` permits network access;
+  it does not accept model terms or establish deployment authorization.
+
   Online preparation retries one transient model or tokenizer load failure.
   Recovery quarantines unreferenced partial cache files before downloading a
   clean replacement. Quarantined files remain on disk for operator review.
@@ -88,6 +92,7 @@ defmodule Mix.Tasks.Obscura.Profile.Prepare do
       profile: profile,
       models: requirements.default_models,
       model_count: length(requirements.default_models),
+      asset_licensing: requirements.asset_licensing,
       cache_directory: cache_dir,
       cache_directory_source: cache_source,
       allow_download: Keyword.get(opts, :allow_download, false),
@@ -109,6 +114,12 @@ defmodule Mix.Tasks.Obscura.Profile.Prepare do
 
   defp render_progress(event, true) do
     Mix.shell().info(Jason.encode!(Map.put(event, :type, :progress)))
+  end
+
+  defp render_progress(%{event: :asset_license_notice} = event, false) do
+    Mix.shell().info(
+      "license_notice asset=#{event.asset} commercial_use=#{event.commercial_use}: #{event.message}"
+    )
   end
 
   defp render_progress(event, false) do

--- a/lib/obscura/capabilities.ex
+++ b/lib/obscura/capabilities.ex
@@ -9,7 +9,8 @@ defmodule Obscura.Capabilities do
   @capabilities_file "obscura/capabilities.json"
   @assets_file "obscura/model_assets.json"
   @required_capability_fields ~w(id status profiles dependencies environment_variables platforms backends network_during_setup network_during_inference setup_command readiness_command smoke_command failure_codes)
-  @required_asset_fields ~w(id status profiles adapter model_repository tokenizer_repository revision_policy required_files hashes license license_review_status license_reviewed_at license_review_revision license_sources network_on_explicit_prepare bundled)
+  @required_asset_fields ~w(id status profiles adapter model_repository tokenizer_repository revision_policy required_files hashes license license_review_status license_reviewed_at license_review_revision commercial_use commercial_use_reviewed_at license_sources network_on_explicit_prepare bundled)
+  @commercial_use_values ~w(requires_ldc_for_profit_membership deployer_review_required not_cleared_by_obscura permissive_chain_documented)
 
   @doc """
   Loads and validates the capability manifest.
@@ -104,9 +105,11 @@ defmodule Obscura.Capabilities do
   defp validate_capability_manifest(_manifest),
     do: {:error, :invalid_capability_manifest_schema}
 
-  defp validate_asset_manifest(%{"schema_version" => 1, "assets" => assets})
+  defp validate_asset_manifest(%{"schema_version" => 2, "assets" => assets})
        when is_list(assets) do
-    validate_rows(assets, @required_asset_fields, :asset)
+    with :ok <- validate_rows(assets, @required_asset_fields, :asset) do
+      validate_commercial_use(assets)
+    end
   end
 
   defp validate_asset_manifest(_manifest), do: {:error, :invalid_asset_manifest_schema}
@@ -134,5 +137,12 @@ defmodule Obscura.Capabilities do
         missing -> {:error, {:missing_manifest_fields, kind, row["id"], missing}}
       end
     end)
+  end
+
+  defp validate_commercial_use(assets) do
+    case Enum.find(assets, &(&1["commercial_use"] not in @commercial_use_values)) do
+      nil -> :ok
+      asset -> {:error, {:invalid_commercial_use, asset["id"], asset["commercial_use"]}}
+    end
   end
 end

--- a/lib/obscura/profile.ex
+++ b/lib/obscura/profile.ex
@@ -8,6 +8,7 @@ defmodule Obscura.Profile do
   shapes follow the `0.1.x` policy in `docs/public-api-stability.md`.
   """
 
+  alias Obscura.Capabilities
   alias Obscura.Diagnostic
   alias Obscura.Eval.EntityMapping
   alias Obscura.Profile.Preflight
@@ -200,7 +201,8 @@ defmodule Obscura.Profile do
          required_assets: descriptor.required_assets,
          default_models: descriptor.default_models,
          backend_policy: descriptor.backend_policy,
-         automatic_download: descriptor.automatic_download
+         automatic_download: descriptor.automatic_download,
+         asset_licensing: asset_licensing(descriptor.name)
        }}
     end
   end
@@ -370,6 +372,25 @@ defmodule Obscura.Profile do
       backend_policy: Keyword.get(attrs, :backend_policy, :explicit),
       automatic_download: false
     }
+  end
+
+  defp asset_licensing(profile) do
+    case Capabilities.assets_for_profile(profile) do
+      {:ok, assets} ->
+        Enum.map(assets, fn asset ->
+          Map.take(asset, [
+            "id",
+            "license_review_status",
+            "commercial_use",
+            "commercial_use_reviewed_at",
+            "license_sources",
+            "bundled"
+          ])
+        end)
+
+      {:error, _reason} ->
+        []
+    end
   end
 
   @doc false

--- a/lib/obscura/profile/preflight.ex
+++ b/lib/obscura/profile/preflight.ex
@@ -201,7 +201,8 @@ defmodule Obscura.Profile.Preflight do
       required_assets: descriptor.required_assets,
       default_models: descriptor.default_models,
       backend_policy: descriptor.backend_policy,
-      automatic_download: descriptor.automatic_download
+      automatic_download: descriptor.automatic_download,
+      asset_licensing: asset_licensing(descriptor.name)
     }
   end
 
@@ -262,7 +263,7 @@ defmodule Obscura.Profile.Preflight do
   defp warnings(%Profile{name: :balanced}, opts) do
     fallback_warning(opts) ++
       [
-        "The profile implementation is stable, but Obscura does not distribute or license the optional TNER checkpoint; the deployer must review and accept its terms before use."
+        tner_commercial_use_warning()
       ]
   end
 
@@ -271,7 +272,8 @@ defmodule Obscura.Profile.Preflight do
       [
         "This stable profile loads two large models and conditionally runs the Jean-Baptiste location specialist when TNER returns no accepted location.",
         "It has the highest measured general accuracy, but balanced remains the practical recommendation because it uses one model and has lower latency.",
-        "Obscura does not distribute or license the optional TNER or Jean-Baptiste assets; the deployer must review and accept their terms before use."
+        tner_commercial_use_warning(),
+        "Obscura does not distribute or license the optional Jean-Baptiste asset; the deployer must review its terms before use."
       ]
   end
 
@@ -288,6 +290,17 @@ defmodule Obscura.Profile.Preflight do
       "This CPU-only profile is experimental and is recommended only when a GPU-free, license-clearer general NER option is preferred over the best measured accuracy.",
       "Its exact F1 is lower than balanced on all three shared datasets, and its ONNX/tokenizer/config assets must be exported and prepared explicitly."
     ]
+  end
+
+  defp asset_licensing(profile) do
+    case Profile.requirements(profile) do
+      {:ok, requirements} -> requirements.asset_licensing
+      {:error, _diagnostic} -> []
+    end
+  end
+
+  defp tner_commercial_use_warning do
+    "Commercial use of tner/roberta-large-ontonotes5 requires an LDC for-profit membership according to direct LDC confirmation dated 2026-07-22. Obscura does not grant or verify that authorization and does not bundle, distribute, sublicense, or license the checkpoint."
   end
 
   defp network_may_be_used?(%Profile{name: :hybrid_gliner_urchade}, _opts), do: false

--- a/lib/obscura/profile/preparation.ex
+++ b/lib/obscura/profile/preparation.ex
@@ -1,6 +1,7 @@
 defmodule Obscura.Profile.Preparation do
   @moduledoc false
 
+  alias Obscura.Capabilities
   alias Obscura.Diagnostic
   alias Obscura.Profile
   alias Obscura.Profile.Cache
@@ -63,6 +64,7 @@ defmodule Obscura.Profile.Preparation do
     reference = make_ref()
     caller = self()
 
+    emit_asset_license_notices(descriptor, config, started)
     emit(config, event(:preparation_started, descriptor, started, config, %{}))
 
     worker_opts =
@@ -552,6 +554,31 @@ defmodule Obscura.Profile.Preparation do
     |> Map.merge(attrs)
     |> Enum.reject(fn {_key, value} -> is_nil(value) end)
     |> Map.new()
+  end
+
+  defp emit_asset_license_notices(descriptor, config, started) do
+    case Capabilities.assets_for_profile(descriptor.name) do
+      {:ok, assets} ->
+        assets
+        |> Enum.filter(&(&1["commercial_use"] == "requires_ldc_for_profit_membership"))
+        |> Enum.each(fn asset ->
+          emit(
+            config,
+            event(:asset_license_notice, descriptor, started, config, %{
+              asset: asset["id"],
+              commercial_use: asset["commercial_use"],
+              license_review_status: asset["license_review_status"],
+              commercial_use_reviewed_at: asset["commercial_use_reviewed_at"],
+              license_sources: asset["license_sources"],
+              message:
+                "Commercial use of #{asset["model_repository"]} requires an LDC for-profit membership. Obscura does not grant or verify that authorization."
+            })
+          )
+        end)
+
+      {:error, _reason} ->
+        :ok
+    end
   end
 
   defp emit(config, progress_event) do

--- a/priv/obscura/model_assets.json
+++ b/priv/obscura/model_assets.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "assets": [
     {
       "id": "tner_roberta_large_ontonotes5",
@@ -13,14 +13,18 @@
       "revision_policy": "load the pinned immutable Hugging Face commit and record it in every authoritative benchmark",
       "required_files": [],
       "hashes": {},
-      "license": "checkpoint license metadata absent; OntoNotes training data is distributed under an LDC agreement; not distributed or sublicensed by Obscura",
-      "license_review_status": "unresolved_external_asset",
-      "license_reviewed_at": "2026-07-21",
+      "license": "commercial use requires an LDC for-profit membership according to direct LDC confirmation; checkpoint redistribution was not conclusively addressed; not bundled, distributed, sublicensed, or licensed by Obscura",
+      "license_review_status": "commercial_use_requires_ldc_membership",
+      "license_reviewed_at": "2026-07-22",
       "license_review_revision": "0bce50f7884d5bb040469c907c897d4b061ccbb4",
+      "commercial_use": "requires_ldc_for_profit_membership",
+      "commercial_use_reviewed_at": "2026-07-22",
       "license_sources": [
         "https://huggingface.co/tner/roberta-large-ontonotes5",
         "https://huggingface.co/datasets/tner/ontonotes5",
-        "https://catalog.ldc.upenn.edu/LDC2013T19"
+        "https://catalog.ldc.upenn.edu/LDC2013T19",
+        "https://catalog.ldc.upenn.edu/license/ldc-non-members-agreement.pdf",
+        "https://catalog.ldc.upenn.edu/license/ldc-for-profit-membership.pdf"
       ],
       "network_on_explicit_prepare": true,
       "bundled": false
@@ -42,6 +46,8 @@
       "license_review_status": "conditional_deployer_review",
       "license_reviewed_at": "2026-07-21",
       "license_review_revision": "8f3abc1ef81ffbbb0e80568d4fed1dd10d459548",
+      "commercial_use": "deployer_review_required",
+      "commercial_use_reviewed_at": "2026-07-21",
       "license_sources": [
         "https://huggingface.co/Jean-Baptiste/roberta-large-ner-english",
         "https://huggingface.co/FacebookAI/roberta-large",
@@ -67,6 +73,8 @@
       "license_review_status": "unresolved_external_asset",
       "license_reviewed_at": "2026-07-21",
       "license_review_revision": "968247329d18998cc7d5338b941b52f1b2a9abd9",
+      "commercial_use": "not_cleared_by_obscura",
+      "commercial_use_reviewed_at": "2026-07-21",
       "license_sources": [
         "https://huggingface.co/OpenMed/privacy-filter-nemotron-v2",
         "https://huggingface.co/openai/privacy-filter",
@@ -98,6 +106,8 @@
       "license_review_status": "permissive_chain_documented",
       "license_reviewed_at": "2026-07-21",
       "license_review_revision": "1fcf13e85f4eef5394e1fcd406cf2ca9ea82351d",
+      "commercial_use": "permissive_chain_documented",
+      "commercial_use_reviewed_at": "2026-07-21",
       "license_sources": [
         "https://huggingface.co/urchade/gliner_multi_pii-v1",
         "https://huggingface.co/urchade/gliner_multi-v2.1",

--- a/test/mix/tasks/obscura.profile.check_test.exs
+++ b/test/mix/tasks/obscura.profile.check_test.exs
@@ -44,4 +44,38 @@ defmodule Mix.Tasks.Obscura.Profile.CheckTest do
       end)
     end
   end
+
+  test "human output discloses the TNER commercial-use restriction" do
+    Mix.Task.reenable("obscura.profile.check")
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, fn ->
+          Check.run(["--profile", "balanced"])
+        end
+      end)
+
+    assert output =~ "Commercial use of tner/roberta-large-ontonotes5"
+    assert output =~ "requires an LDC for-profit membership"
+  end
+
+  test "JSON output includes machine-readable TNER commercial-use metadata" do
+    Mix.Task.reenable("obscura.profile.check")
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, fn ->
+          Check.run(["--profile", "accurate", "--json"])
+        end
+      end)
+
+    report = Jason.decode!(output)
+
+    assert Enum.any?(report["requirements"]["asset_licensing"], fn asset ->
+             asset["id"] == "tner_roberta_large_ontonotes5" and
+               asset["commercial_use"] == "requires_ldc_for_profit_membership"
+           end)
+
+    assert Enum.any?(report["warnings"], &String.contains?(&1, "LDC for-profit membership"))
+  end
 end

--- a/test/mix/tasks/obscura.profile.prepare_test.exs
+++ b/test/mix/tasks/obscura.profile.prepare_test.exs
@@ -5,6 +5,30 @@ defmodule Mix.Tasks.Obscura.Profile.PrepareTest do
 
   alias Mix.Tasks.Obscura.Profile.Prepare
 
+  setup_all do
+    cache_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "obscura-profile-prepare-test-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(cache_dir)
+    previous = System.get_env("BUMBLEBEE_CACHE_DIR")
+    System.put_env("BUMBLEBEE_CACHE_DIR", cache_dir)
+
+    on_exit(fn ->
+      if previous do
+        System.put_env("BUMBLEBEE_CACHE_DIR", previous)
+      else
+        System.delete_env("BUMBLEBEE_CACHE_DIR")
+      end
+
+      File.rm_rf!(cache_dir)
+    end)
+
+    :ok
+  end
+
   test "renders human progress for dependency-light preparation" do
     Mix.Task.reenable("obscura.profile.prepare")
 
@@ -28,4 +52,44 @@ defmodule Mix.Tasks.Obscura.Profile.PrepareTest do
     assert Enum.any?(records, &(&1["event"] == "preparation_started"))
     refute output =~ "[="
   end
+
+  test "human mode prints the TNER commercial restriction before preparation fails" do
+    Mix.Task.reenable("obscura.profile.prepare")
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, fn ->
+          Prepare.run(["--profile", "balanced"])
+        end
+      end)
+
+    assert output =~ "license_notice asset=tner_roberta_large_ontonotes5"
+    assert output =~ "commercial_use=requires_ldc_for_profit_membership"
+    assert output =~ "requires an LDC for-profit membership"
+    assert position(output, "license_notice") < position(output, "preparation_started")
+  end
+
+  test "JSON mode exposes structured TNER licensing before preparation fails" do
+    Mix.Task.reenable("obscura.profile.prepare")
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, fn ->
+          Prepare.run(["--profile", "accurate", "--json"])
+        end
+      end)
+
+    records = output |> String.split("\n", trim: true) |> Enum.map(&Jason.decode!/1)
+    notice = Enum.find(records, &(&1["event"] == "asset_license_notice"))
+
+    assert notice["asset"] == "tner_roberta_large_ontonotes5"
+    assert notice["commercial_use"] == "requires_ldc_for_profit_membership"
+    assert notice["type"] == "progress"
+
+    notice_index = Enum.find_index(records, &(&1["event"] == "asset_license_notice"))
+    started_index = Enum.find_index(records, &(&1["event"] == "preparation_started"))
+    assert notice_index < started_index
+  end
+
+  defp position(output, pattern), do: output |> :binary.match(pattern) |> elem(0)
 end

--- a/test/obscura/capabilities_test.exs
+++ b/test/obscura/capabilities_test.exs
@@ -5,13 +5,14 @@ defmodule Obscura.CapabilitiesTest do
   alias Obscura.Profile
 
   @conditional_dependencies ~w(exla emily ortex tokenizers)
-  @license_review_statuses ~w(conditional_deployer_review permissive_chain_documented unresolved_external_asset)
+  @license_review_statuses ~w(commercial_use_requires_ldc_membership conditional_deployer_review permissive_chain_documented unresolved_external_asset)
+  @commercial_use_values ~w(requires_ldc_for_profit_membership deployer_review_required not_cleared_by_obscura permissive_chain_documented)
 
   test "capability and model asset manifests are valid" do
     assert {:ok, %{"schema_version" => 1, "capabilities" => capabilities}} =
              Capabilities.load()
 
-    assert {:ok, %{"schema_version" => 1, "assets" => assets}} =
+    assert {:ok, %{"schema_version" => 2, "assets" => assets}} =
              Capabilities.load_assets()
 
     assert capabilities != []
@@ -116,11 +117,9 @@ defmodule Obscura.CapabilitiesTest do
       assert Enum.all?(assets, fn asset ->
                asset["status"] == "stable_profile_external_asset" and
                  asset["bundled"] == false and
-                 asset["license_review_status"] in [
-                   "conditional_deployer_review",
-                   "unresolved_external_asset"
-                 ] and
-                 String.contains?(asset["license"], "not distributed or sublicensed by Obscura")
+                 asset["license_review_status"] in @license_review_statuses and
+                 asset["commercial_use"] in @commercial_use_values and
+                 String.contains?(asset["license"], "Obscura")
              end)
     end
   end
@@ -130,12 +129,39 @@ defmodule Obscura.CapabilitiesTest do
 
     for asset <- assets do
       assert asset["license_review_status"] in @license_review_statuses
-      assert asset["license_reviewed_at"] == "2026-07-21"
+      assert asset["commercial_use"] in @commercial_use_values
+      assert {:ok, _date} = Date.from_iso8601(asset["license_reviewed_at"])
+      assert {:ok, _date} = Date.from_iso8601(asset["commercial_use_reviewed_at"])
       assert is_binary(asset["license_review_revision"])
       assert asset["license_review_revision"] != ""
       assert [_ | _] = asset["license_sources"]
       assert Enum.all?(asset["license_sources"], &String.starts_with?(&1, "https://"))
       assert asset["bundled"] == false
     end
+  end
+
+  test "TNER records the confirmed LDC commercial-use restriction" do
+    assert {:ok, assets} = Capabilities.assets_for_profile(:balanced)
+    assert [tner] = assets
+
+    assert tner["license_review_status"] == "commercial_use_requires_ldc_membership"
+    assert tner["commercial_use"] == "requires_ldc_for_profit_membership"
+    assert tner["commercial_use_reviewed_at"] == "2026-07-22"
+    assert tner["bundled"] == false
+
+    assert "https://catalog.ldc.upenn.edu/license/ldc-non-members-agreement.pdf" in tner[
+             "license_sources"
+           ]
+
+    assert "https://catalog.ldc.upenn.edu/license/ldc-for-profit-membership.pdf" in tner[
+             "license_sources"
+           ]
+
+    assert {:ok, requirements} = Profile.requirements(:balanced)
+    assert [licensing] = requirements.asset_licensing
+    assert licensing["commercial_use"] == "requires_ldc_for_profit_membership"
+
+    assert {:ok, fast_requirements} = Profile.requirements(:fast)
+    assert fast_requirements.asset_licensing == []
   end
 end

--- a/test/obscura/profile/preflight_test.exs
+++ b/test/obscura/profile/preflight_test.exs
@@ -49,7 +49,10 @@ defmodule Obscura.Profile.PreflightTest do
              )
 
     assert balanced.stability == :stable
-    assert Enum.any?(balanced.warnings, &String.contains?(&1, "does not distribute or license"))
+    assert Enum.any?(balanced.warnings, &String.contains?(&1, "Commercial use"))
+    assert Enum.any?(balanced.warnings, &String.contains?(&1, "LDC for-profit membership"))
+    assert [balanced_licensing] = balanced.requirements.asset_licensing
+    assert balanced_licensing["commercial_use"] == "requires_ldc_for_profit_membership"
 
     assert {:ok, accurate} =
              Profile.preflight(:accurate,
@@ -60,7 +63,20 @@ defmodule Obscura.Profile.PreflightTest do
              )
 
     assert accurate.stability == :stable
-    assert Enum.any?(accurate.warnings, &String.contains?(&1, "deployer must review"))
+    assert Enum.any?(accurate.warnings, &String.contains?(&1, "LDC for-profit membership"))
+
+    assert Enum.any?(
+             accurate.requirements.asset_licensing,
+             &(&1["commercial_use"] == "requires_ldc_for_profit_membership")
+           )
+  end
+
+  test "fast preflight contains no TNER licensing restriction" do
+    assert {:ok, report} = Profile.preflight(:fast)
+
+    assert report.requirements.asset_licensing == []
+    refute Enum.any?(report.warnings, &String.contains?(&1, "LDC"))
+    refute Enum.any?(report.warnings, &String.contains?(&1, "TNER"))
   end
 
   test "OpenMed preflight distinguishes a missing checkpoint config" do

--- a/test/obscura/profile/preparation_test.exs
+++ b/test/obscura/profile/preparation_test.exs
@@ -75,7 +75,10 @@ defmodule Obscura.Profile.PreparationTest do
              )
 
     events = collect_progress([])
-    assert hd(events).event == :preparation_started
+    assert hd(events).event == :asset_license_notice
+    assert hd(events).asset == "tner_roberta_large_ontonotes5"
+    assert hd(events).commercial_use == "requires_ldc_for_profit_membership"
+    assert Enum.at(events, 1).event == :preparation_started
     assert List.last(events).event == :preparation_completed
 
     started_models =
@@ -90,7 +93,7 @@ defmodule Obscura.Profile.PreparationTest do
     assert Enum.any?(events, &(&1[:model_index] == 2 and &1[:model_count] == 2))
 
     encoded = Jason.encode!(events)
-    refute encoded =~ "authorization"
+    refute encoded =~ "auth_token"
     refute encoded =~ "raw_text"
     refute encoded =~ System.user_home!()
   end
@@ -98,6 +101,17 @@ defmodule Obscura.Profile.PreparationTest do
   test "progress callback failures do not abort preparation" do
     assert {:ok, _runtime} =
              Profile.prepare(:fast, progress: fn _event -> raise "callback failed" end)
+  end
+
+  test "fast preparation emits no model asset license notice" do
+    parent = self()
+
+    assert {:ok, _runtime} =
+             Profile.prepare(:fast,
+               progress: fn event -> send(parent, {:progress, event}) end
+             )
+
+    refute Enum.any?(collect_progress([]), &(&1.event == :asset_license_notice))
   end
 
   test "overall timeout terminates controlled preparation" do


### PR DESCRIPTION
## Summary

- record LDC's 2026-07-22 confirmation that commercial use of `tner/roberta-large-ontonotes5` requires an LDC for-profit membership
- expose machine-readable commercial-use metadata through capabilities, profile requirements, and preflight reports
- emit asset-license notices before profile preparation or model downloads, including human and JSON Mix task output
- update public documentation while keeping `:fast` unaffected and `:balanced`/`:accurate` technically stable

## Legal scope

Obscura does not bundle, distribute, sublicense, license, or grant rights to the checkpoint. LDC did not conclusively answer the separate checkpoint-redistribution question, so this change does not claim that redistribution is prohibited or permitted.

## Validation

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test` (730 passed, 14 excluded)
- `mix credo --strict --all`
- `mix obscura.docs.verify` (81 files)
- `mix docs`
- `mix hex.build`
- desktop and 390px mobile ExDoc review with no browser console errors
