### PR TITLE
Preserve asset schema compatibility

### DIFF
--- a/docs/blog/protecting-pii-in-elixir.md
+++ b/docs/blog/protecting-pii-in-elixir.md
@@ -389,9 +389,17 @@ These numbers explain the profile split:
 
 - `:fast` favors precision, low latency, and minimal dependencies, but misses
   open-class entities.
-- `:balanced` is the practical general-text recommendation.
+- `:balanced` is the practical general-text recommendation when its external
+  asset terms are acceptable for the deployment.
 - `:accurate` adds a conditional location-recovery model and produces the
   highest measured general F1, with more preparation, memory, and latency.
+
+Both model-backed profiles use `tner/roberta-large-ontonotes5`. In direct
+correspondence on July 22, 2026, LDC confirmed that commercial use of this
+OntoNotes-trained checkpoint requires an LDC for-profit membership. Obscura
+does not grant or verify that authorization. This does not disable local
+evaluation of these profiles; users remain responsible for confirming that
+their use complies with the applicable LDC and upstream terms.
 
 The table is evidence for those particular datasets, entity mappings, and
 hardware conditions. It is not evidence that Obscura is universally more

--- a/lib/obscura/capabilities.ex
+++ b/lib/obscura/capabilities.ex
@@ -105,7 +105,7 @@ defmodule Obscura.Capabilities do
   defp validate_capability_manifest(_manifest),
     do: {:error, :invalid_capability_manifest_schema}
 
-  defp validate_asset_manifest(%{"schema_version" => 2, "assets" => assets})
+  defp validate_asset_manifest(%{"schema_version" => 1, "assets" => assets})
        when is_list(assets) do
     with :ok <- validate_rows(assets, @required_asset_fields, :asset) do
       validate_commercial_use(assets)

--- a/priv/obscura/model_assets.json
+++ b/priv/obscura/model_assets.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "assets": [
     {
       "id": "tner_roberta_large_ontonotes5",

--- a/test/obscura/capabilities_test.exs
+++ b/test/obscura/capabilities_test.exs
@@ -12,7 +12,7 @@ defmodule Obscura.CapabilitiesTest do
     assert {:ok, %{"schema_version" => 1, "capabilities" => capabilities}} =
              Capabilities.load()
 
-    assert {:ok, %{"schema_version" => 2, "assets" => assets}} =
+    assert {:ok, %{"schema_version" => 1, "assets" => assets}} =
              Capabilities.load_assets()
 
     assert capabilities != []


### PR DESCRIPTION
## Summary

- retain model asset manifest schema version 1 while adding licensing fields additively
- keep `Obscura.Capabilities` compatible with callers matching the published schema
- disclose the checkpoint-specific OntoNotes/LDC requirement in the canonical PII article without disabling local evaluation

## Validation

- `mix format --check-formatted`
- `mix test test/obscura/capabilities_test.exs`
- `mix docs`
- `mix run scripts/build_pages.exs`
- `mix run scripts/verify_pages.exs`
- `git diff --check`