### PR TITLE
Release Obscura 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 All notable changes to Obscura are documented in this file.
 
-## Unreleased
+## 0.1.1 - 2026-07-22
 
-- Documented LDC's confirmation that commercial use of the optional TNER
-  checkpoint requires an LDC for-profit membership.
+- Documented LDC's confirmation that commercial use of
+  `tner/roberta-large-ontonotes5` requires an LDC for-profit membership.
 - Added machine-readable asset licensing metadata plus preflight and
   preparation notices for the affected `:balanced` and `:accurate` profiles.
+- Preserved model-asset manifest schema version 1 while adding licensing fields
+  compatibly.
 - Kept `:fast` dependency-light and unaffected by the TNER requirement.
 
 ## 0.1.0 - 2026-07-21

--- a/docs/blog/protecting-pii-in-elixir.md
+++ b/docs/blog/protecting-pii-in-elixir.md
@@ -51,7 +51,7 @@ where it runs, which entities it looks for, and what happens to the original.
 
 ## Install Obscura
 
-Obscura 0.1.0 is available from Hex:
+Obscura is available from Hex:
 
 ```elixir
 def deps do
@@ -457,7 +457,7 @@ The same ten-second walkthrough is available as a higher-resolution
 
 The library source and installation instructions are available in the
 [Obscura repository](https://github.com/hfiguera/obscura), with API
-documentation on [HexDocs](https://hexdocs.pm/obscura/0.1.0/).
+documentation on [HexDocs](https://hexdocs.pm/obscura/).
 
 Protecting PII is most effective when it is treated as an application-boundary
 decision. Detect what the next system does not need, transform it before the

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Obscura.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
   @source_url "https://github.com/hfiguera/obscura"
   @security_url "#{@source_url}/security/advisories/new"
 

--- a/scripts/build_pages.exs
+++ b/scripts/build_pages.exs
@@ -42,7 +42,7 @@ defmodule Obscura.PagesBuilder do
     |> ExDoc.DocAST.to_html()
     |> String.replace(
       "</h1>",
-      "</h1>\n<p class=\"article-meta\">Published #{@published_on} · Obscura 0.1.0</p>",
+      "</h1>\n<p class=\"article-meta\">Published #{@published_on} · Obscura 0.1.x</p>",
       global: false
     )
   end
@@ -104,7 +104,7 @@ defmodule Obscura.PagesBuilder do
             </span>
           </a>
           <nav aria-label="Project links">
-            <a href="https://hexdocs.pm/obscura/0.1.0/">Docs</a>
+            <a href="https://hexdocs.pm/obscura/">Docs</a>
             <a href="https://github.com/hfiguera/obscura_examples">Workbench</a>
             <a href="https://github.com/hfiguera/obscura">GitHub</a>
           </nav>
@@ -113,7 +113,7 @@ defmodule Obscura.PagesBuilder do
           <article>#{article}</article>
         </main>
         <footer>
-          <p>Obscura is an early-release, library-first PII toolkit for Elixir.</p>
+          <p>Obscura is a library-first toolkit for detecting and anonymizing PII in Elixir.</p>
           <p><a href="https://github.com/hfiguera/obscura">Source</a> · <a href="https://hex.pm/packages/obscura">Hex</a> · <a href="../../feed.xml">RSS</a></p>
         </footer>
       </body>

--- a/test/obscura/release_metadata_test.exs
+++ b/test/obscura/release_metadata_test.exs
@@ -8,7 +8,7 @@ defmodule Obscura.ReleaseMetadataTest do
     project = Mix.Project.config()
     package = Keyword.fetch!(project, :package)
 
-    assert project[:version] == "0.1.0"
+    assert project[:version] == "0.1.1"
     assert project[:source_url] == @source_url
     assert project[:homepage_url] == @source_url
     assert package[:links]["GitHub"] == @source_url


### PR DESCRIPTION
## Summary

- release Obscura 0.1.1 with the confirmed checkpoint-specific LDC disclosure and machine-readable preparation notices
- preserve model asset manifest schema version 1 while adding licensing fields compatibly
- keep the canonical article version-neutral across the supported 0.1.x line

## Validation

- `mix ci.base`
- `mix hex.build`
- package SHA-256: `4726751448e85eb38711fa41caca9a461ccd76ad3bb59fd35c8528d2132a745c`
- unpacked package compiled with `--warnings-as-errors` in a clean consumer project
- clean consumer verified `:fast`, package version 0.1.1, manifest schema 1, and TNER licensing metadata
- Pages build and verification passed