### PR TITLE
Add Cloudflare Web Analytics to the blog

### DIFF
--- a/scripts/build_pages.exs
+++ b/scripts/build_pages.exs
@@ -9,6 +9,7 @@ defmodule Obscura.PagesBuilder do
   @article_output Path.join([@output_root, "blog", @article_slug])
   @canonical_url "https://hfiguera.github.io/obscura/blog/#{@article_slug}/"
   @site_url "https://hfiguera.github.io/obscura/"
+  @analytics_token "f968ea7d6e614cc9a3e2d537ced91a10"
   @title "Protecting PII in Elixir Before It Reaches Logs, APIs, and LLMs"
   @description "A practical guide to detecting, redacting, and pseudonymizing PII at Elixir application boundaries with Obscura."
   @published_on "2026-07-22"
@@ -26,6 +27,7 @@ defmodule Obscura.PagesBuilder do
 
     write_article(article)
     write_root_redirect()
+    write_privacy()
     write_feed()
     write_sitemap()
     copy_assets()
@@ -114,8 +116,9 @@ defmodule Obscura.PagesBuilder do
         </main>
         <footer>
           <p>Obscura is a library-first toolkit for detecting and anonymizing PII in Elixir.</p>
-          <p><a href="https://github.com/hfiguera/obscura">Source</a> · <a href="https://hex.pm/packages/obscura">Hex</a> · <a href="../../feed.xml">RSS</a></p>
+          <p><a href="https://github.com/hfiguera/obscura">Source</a> · <a href="https://hex.pm/packages/obscura">Hex</a> · <a href="../../feed.xml">RSS</a> · <a href="../../privacy/">Analytics privacy</a></p>
         </footer>
+        #{analytics_beacon()}
       </body>
     </html>
     """
@@ -136,11 +139,79 @@ defmodule Obscura.PagesBuilder do
       </head>
       <body>
         <p><a href="blog/#{@article_slug}/">Read #{@title}</a></p>
+        #{analytics_beacon()}
       </body>
     </html>
     """
 
     File.write!(Path.join(@output_root, "index.html"), html)
+  end
+
+  defp write_privacy do
+    output = Path.join(@output_root, "privacy")
+    File.mkdir_p!(output)
+
+    canonical_url = @site_url <> "privacy/"
+
+    html = """
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Analytics privacy · Obscura</title>
+        <meta name="description" content="How the Obscura engineering blog uses privacy-focused website analytics.">
+        <meta name="theme-color" content="#151c1a">
+        <link rel="canonical" href="#{canonical_url}">
+        <link rel="alternate" type="application/rss+xml" title="Obscura articles" href="#{@site_url}feed.xml">
+        <link rel="stylesheet" href="../assets/site.css">
+      </head>
+      <body>
+        <a class="skip-link" href="#privacy">Skip to privacy information</a>
+        <header class="site-header">
+          <a class="brand" href="../" aria-label="Obscura home">
+            <span class="brand-mark" aria-hidden="true">O</span>
+            <span>
+              <strong>Obscura</strong>
+              <small>PII detection and anonymization for Elixir</small>
+            </span>
+          </a>
+          <nav aria-label="Project links">
+            <a href="https://hexdocs.pm/obscura/">Docs</a>
+            <a href="https://github.com/hfiguera/obscura_examples">Workbench</a>
+            <a href="https://github.com/hfiguera/obscura">GitHub</a>
+          </nav>
+        </header>
+        <main id="privacy" class="article-shell">
+          <article>
+            <h1>Analytics privacy</h1>
+            <p>
+              This site uses Cloudflare Web Analytics to understand aggregate
+              page visits, referring sites, and page performance.
+            </p>
+            <p>
+              The analytics beacon does not use cookies or local storage, and
+              Cloudflare Web Analytics does not log URL query strings or support
+              custom tracking events. The browser sends measurements to
+              Cloudflare when a page loads and when it is left.
+            </p>
+            <p>
+              Blocking the analytics script does not change the content or
+              functionality of this site. For implementation details, see
+              <a href="https://developers.cloudflare.com/web-analytics/data-metrics/data-origin-and-collection/">Cloudflare's data collection documentation</a>.
+            </p>
+          </article>
+        </main>
+        <footer>
+          <p>Obscura is a library-first toolkit for detecting and anonymizing PII in Elixir.</p>
+          <p><a href="https://github.com/hfiguera/obscura">Source</a> · <a href="https://hex.pm/packages/obscura">Hex</a> · <a href="../feed.xml">RSS</a> · <a href="./">Analytics privacy</a></p>
+        </footer>
+        #{analytics_beacon()}
+      </body>
+    </html>
+    """
+
+    File.write!(Path.join(output, "index.html"), html)
   end
 
   defp write_feed do
@@ -175,6 +246,10 @@ defmodule Obscura.PagesBuilder do
         <loc>#{@canonical_url}</loc>
         <lastmod>#{@published_on}</lastmod>
       </url>
+      <url>
+        <loc>#{@site_url}privacy/</loc>
+        <lastmod>#{@published_on}</lastmod>
+      </url>
     </urlset>
     """
 
@@ -197,6 +272,14 @@ defmodule Obscura.PagesBuilder do
     |> Path.wildcard()
     |> Enum.filter(&(Path.extname(&1) in [".gif", ".jpg", ".mp4"]))
     |> Enum.each(&File.cp!(&1, Path.join(media_output, Path.basename(&1))))
+  end
+
+  defp analytics_beacon do
+    """
+    <!-- Cloudflare Web Analytics -->
+    <script type="module" src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token":"#{@analytics_token}"}'></script>
+    <!-- End Cloudflare Web Analytics -->
+    """
   end
 
   defp xml_escape(value) do

--- a/scripts/verify_pages.exs
+++ b/scripts/verify_pages.exs
@@ -6,6 +6,7 @@ defmodule Obscura.PagesVerifier do
   @article_dir Path.join([@root, "blog", @slug])
   @article Path.join(@article_dir, "index.html")
   @canonical "https://hfiguera.github.io/obscura/blog/#{@slug}/"
+  @site_url "https://hfiguera.github.io/obscura/"
 
   def run do
     article = File.read!(@article)
@@ -21,6 +22,7 @@ defmodule Obscura.PagesVerifier do
     assert_contains(article, "obscura-pii-boundary-workflow.mp4")
     refute_contains(article, "TODO(media)")
     refute_contains(article, "localhost")
+    assert_analytics_beacon(article)
 
     assert_file("assets/site.css")
     assert_file("assets/syntax.css")
@@ -34,18 +36,59 @@ defmodule Obscura.PagesVerifier do
     assert_magic(Path.join(media_dir, "obscura-pii-boundary-workflow.gif"), "GIF89a")
     assert_ftyp(Path.join(media_dir, "obscura-pii-boundary-workflow.mp4"))
 
-    assert_local_references_exist(article)
+    assert_local_references_exist(article, @article_dir)
+    verify_root_redirect()
+    verify_privacy()
+    verify_sitemap()
+
     IO.puts("Verified #{@canonical}")
   end
 
-  defp assert_local_references_exist(article) do
+  defp verify_root_redirect do
+    index = File.read!(Path.join(@root, "index.html"))
+
+    assert_contains(index, ~s(http-equiv="refresh"))
+    assert_analytics_beacon(index)
+    assert_local_references_exist(index, @root)
+  end
+
+  defp verify_privacy do
+    privacy_dir = Path.join(@root, "privacy")
+    html = File.read!(Path.join(privacy_dir, "index.html"))
+
+    assert_contains(html, ~s(<link rel="canonical" href="#{@site_url}privacy/">))
+    assert_contains(html, "Analytics privacy")
+    assert_contains(html, "does not use cookies or local storage")
+    assert_contains(html, "does not log URL query strings")
+    assert_analytics_beacon(html)
+    assert_local_references_exist(html, privacy_dir)
+  end
+
+  defp verify_sitemap do
+    sitemap = File.read!(Path.join(@root, "sitemap.xml"))
+    assert_contains(sitemap, "#{@site_url}privacy/")
+  end
+
+  defp assert_analytics_beacon(html) do
+    beacon = "https://static.cloudflareinsights.com/beacon.min.js"
+    token = ~s("token":"f968ea7d6e614cc9a3e2d537ced91a10")
+
+    assert_contains(html, beacon)
+    assert_contains(html, token)
+
+    if length(:binary.matches(html, beacon)) != 1 do
+      raise "expected exactly one Cloudflare Web Analytics beacon"
+    end
+  end
+
+  defp assert_local_references_exist(html, base_dir) do
     ~r/(?:href|src)="([^"]+)"/
-    |> Regex.scan(article, capture: :all_but_first)
+    |> Regex.scan(html, capture: :all_but_first)
     |> List.flatten()
     |> Enum.reject(&external_or_special?/1)
     |> Enum.each(fn reference ->
       reference = reference |> String.split("#", parts: 2) |> hd()
-      path = Path.expand(reference, @article_dir)
+      path = Path.expand(reference, base_dir)
 
       unless File.exists?(path) do
         raise "missing local page reference #{reference} (resolved to #{path})"


### PR DESCRIPTION
## Summary

- add Cloudflare Web Analytics to the published blog article and root redirect
- publish a concise analytics privacy page and footer disclosure
- keep analytics independent from site rendering and navigation
- verify every generated HTML page contains exactly one analytics beacon

## Validation

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix run scripts/build_pages.exs`
- `mix run scripts/verify_pages.exs`

## Deployment note

The Pages workflow builds and verifies this pull request without deploying it. Analytics begins collecting only after merge to `main` and deployment to the configured `hfiguera.github.io` hostname.