### PR TITLE
Fix real-model replacement options

### DIFF
--- a/lib/obscura/recognizer/ner/real_model_smoke.ex
+++ b/lib/obscura/recognizer/ner/real_model_smoke.ex
@@ -65,7 +65,7 @@ defmodule Obscura.Recognizer.NER.RealModelSmoke do
 
   defp redaction_opts(serving, opts) do
     analyzer_opts(serving, opts)
-    |> Keyword.put(:operators, %{default: %{type: :replace, new_value: "[REDACTED]"}})
+    |> Keyword.put(:operators, %{default: %{type: :replace, value: "[REDACTED]"}})
   end
 
   defp pseudonymize(text, serving, vault, opts) do

--- a/test/obscura/privacy_filter/real_model_test.exs
+++ b/test/obscura/privacy_filter/real_model_test.exs
@@ -33,7 +33,7 @@ defmodule Obscura.PrivacyFilter.RealModelTest do
              Obscura.redact(text,
                entities: entities,
                recognizers: recognizers,
-               operators: %{default: %{type: :replace, new_value: "[REDACTED]"}}
+               operators: %{default: %{type: :replace, value: "[REDACTED]"}}
              )
 
     assert redacted.text != text

--- a/test/obscura/recognizer/ner/real_model_test.exs
+++ b/test/obscura/recognizer/ner/real_model_test.exs
@@ -35,7 +35,7 @@ defmodule Obscura.Recognizer.NER.RealModelTest do
              Obscura.redact(text,
                entities: [:person, :organization, :location],
                recognizers: [{NER, serving: serving, label_map: serving.model_spec.label_map}],
-               operators: %{default: %{type: :replace, new_value: "[REDACTED]"}},
+               operators: %{default: %{type: :replace, value: "[REDACTED]"}},
                recognizer_timeout: 60_000
              )
 
@@ -59,7 +59,7 @@ defmodule Obscura.Recognizer.NER.RealModelTest do
              Obscura.redact(%{message: text},
                entities: [:person, :organization, :location],
                recognizers: [{NER, serving: serving, label_map: serving.model_spec.label_map}],
-               operators: %{default: %{type: :replace, new_value: "[REDACTED]"}}
+               operators: %{default: %{type: :replace, value: "[REDACTED]"}}
              )
 
     assert structured.data.message != text


### PR DESCRIPTION
## Summary

- replace stale `new_value` operator options with the stable `value` option
- update the reusable NER real-model smoke helper
- keep NER and privacy-filter real-checkpoint tests aligned with the public operator contract

## Validation

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- real NER and OpenMed tests through Emily GPU with fallback disabled: 2 passed
- `git diff --check`