### PR TITLE
Add privacy-safe Phoenix realtime logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable changes to Obscura are documented in this file.
 - Added opt-in privacy-safe Phoenix socket and channel telemetry loggers with
   omission-first payload policies, configured topic patterns and event names,
   bounded `:fast` redaction, and raw-default-logger conflict detection.
-- Bounded raw channel-topic validation and rejected PII-bearing correlation
-  metadata keys during logger startup.
+- Bounded realtime parameter analysis, owned allowed event labels, rejected
+  unsafe configured labels, and rejected correlation metadata keys containing
+  high-confidence PII recognized by the `:fast` profile.
 
 ## 0.1.2 - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to Obscura are documented in this file.
 - Bounded realtime parameter analysis, owned allowed event labels, rejected
   unsafe configured labels, and rejected correlation metadata keys containing
   high-confidence PII recognized by the `:fast` profile.
+- Added a 4 KiB realtime parameter-text ceiling so dense socket and channel
+  payloads fail closed before synchronous PII recognition.
 
 ## 0.1.2 - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to Obscura are documented in this file.
   payloads fail closed before synchronous PII recognition.
 - Hardened realtime identifier validation against prefixed structured PII and
   bounded Phoenix parameter-filter configuration before event handling.
+- Made the privacy-safe HTTP logger reject startup while any corresponding
+  Phoenix default logger is attached, and made the Plug validate and normalize
+  its integration options during `init/1`.
+- Added real Phoenix endpoint coverage and a sustained real socket/channel
+  redaction regression test.
 
 ## 0.1.2 - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to Obscura are documented in this file.
 - Added opt-in privacy-safe Phoenix socket and channel telemetry loggers with
   omission-first payload policies, configured topic patterns and event names,
   bounded `:fast` redaction, and raw-default-logger conflict detection.
+- Bounded raw channel-topic validation and rejected PII-bearing correlation
+  metadata keys during logger startup.
 
 ## 0.1.2 - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Obscura are documented in this file.
 
+## Unreleased
+
+- Added opt-in privacy-safe Phoenix socket and channel telemetry loggers with
+  omission-first payload policies, configured topic patterns and event names,
+  bounded `:fast` redaction, and raw-default-logger conflict detection.
+
 ## 0.1.2 - 2026-07-24
 
 - Improved `:fast` latency and throughput, with the largest gains on large

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to Obscura are documented in this file.
   high-confidence PII recognized by the `:fast` profile.
 - Added a 4 KiB realtime parameter-text ceiling so dense socket and channel
   payloads fail closed before synchronous PII recognition.
+- Hardened realtime identifier validation against prefixed structured PII and
+  bounded Phoenix parameter-filter configuration before event handling.
 
 ## 0.1.2 - 2026-07-24
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ plug Obscura.Phoenix.Plug,
   entities: [:email]
 ```
 
+Opt-in Phoenix telemetry handlers provide privacy-safe HTTP request, socket,
+and channel logging. Realtime payloads are omitted by default; channel topics
+and event names use explicit application-configured labels rather than raw
+client values.
+
 Telemetry events include durations, counts, entities, and statuses, but omit
 raw text and span values. See [Logger and Plug integration](docs/logger-and-plug.md).
 

--- a/docs/logger-and-plug.md
+++ b/docs/logger-and-plug.md
@@ -188,7 +188,8 @@ children = [
 
 The logger emits the matched configured pattern, not the raw topic. Unmatched
 topics become `[FILTERED TOPIC]`, and unconfigured event names become
-`[FILTERED EVENT]`. Phoenix's internal `"phoenix"` topics remain silent. The
+`[FILTERED EVENT]`. Oversized topics are filtered before UTF-8 validation or
+pattern matching. Phoenix's internal `"phoenix"` topics remain silent. The
 handler preserves the channel's `:log_join` and `:log_handle_in` levels.
 
 Join and incoming-event parameters are independently omitted by default. A
@@ -214,7 +215,8 @@ as Logger metadata, allowing related channel events to be correlated:
 
 The assign name becomes the Logger metadata key. It must be a bounded static
 identifier and must not collide with Logger-reserved metadata such as `:pid`,
-`:gl`, `:time`, or `:domain`; invalid keys fail startup.
+`:gl`, `:time`, or `:domain`. PII-bearing keys are also rejected; invalid keys
+fail startup.
 
 The assign is included only for successful joins and handled events, and only
 when it is a canonical UUID string. Missing, malformed, or non-binary values

--- a/docs/logger-and-plug.md
+++ b/docs/logger-and-plug.md
@@ -134,5 +134,89 @@ request schema, and verify representative payloads before enabling parameter
 logging in production.
 
 This integration does not sanitize reverse-proxy logs, web-server access logs,
-socket/channel parameter logs, traces installed before the plug, or arbitrary
-application logs. Configure those boundaries independently.
+traces installed before the plug, or arbitrary application logs. Configure
+those boundaries independently.
+
+## Privacy-safe Phoenix socket logging
+
+Disabling Phoenix's default logger also disables its socket connection and
+socket drain records. `Obscura.Phoenix.SocketLogger` restores those records
+without logging `connect_info` and omits connection parameters by default:
+
+```elixir
+children = [
+  {Obscura.Phoenix.Logger, assign: :obscura_redacted},
+  {Obscura.Phoenix.SocketLogger, connect_params: :omit}
+]
+```
+
+The connection result, socket module, transport, serializer, and duration are
+validated before logging. Drain records contain only validated counts, the
+socket module, and the configured interval. Invalid identifiers and
+measurements become fixed filtered or unknown labels.
+
+Applications can explicitly include a bounded redacted copy of connection
+parameters:
+
+```elixir
+{Obscura.Phoenix.SocketLogger,
+ connect_params:
+   {:redact,
+    entities: [:email, :phone, :credit_card, :us_ssn]}}
+```
+
+Realtime parameter redaction accepts only the dependency-light `:fast` profile
+and a narrow set of declarative redaction options. It does not accept
+model-backed profiles, custom recognizers, parser callbacks, or automatic asset
+preparation. Parameter graphs use the same key, byte, node, analysis, and
+numeric limits as request logging and fail closed as `[FILTERED]`.
+
+## Privacy-safe Phoenix channel logging
+
+`Obscura.Phoenix.ChannelLogger` restores channel join and incoming-event logs.
+Raw channel topics and event names are client-controlled, so they are not
+logged directly. Configure the static topic patterns and event names that are
+safe to expose:
+
+```elixir
+children = [
+  {Obscura.Phoenix.ChannelLogger,
+   topic_patterns: ["room:*", "users:*", "system"],
+   events: ["new_message", "typing", "mark_read"]}
+]
+```
+
+The logger emits the matched configured pattern, not the raw topic. Unmatched
+topics become `[FILTERED TOPIC]`, and unconfigured event names become
+`[FILTERED EVENT]`. Phoenix's internal `"phoenix"` topics remain silent. The
+handler preserves the channel's `:log_join` and `:log_handle_in` levels.
+
+Join and incoming-event parameters are independently omitted by default. A
+bounded redacted copy can be enabled explicitly:
+
+```elixir
+{Obscura.Phoenix.ChannelLogger,
+ topic_patterns: ["room:*"],
+ events: ["new_message"],
+ join_params: {:redact, entities: [:email, :phone]},
+ handle_in_params: {:redact, entities: [:email, :phone]}}
+```
+
+The handler never inspects socket assigns, application-private socket data,
+socket identifiers, message references, callback results, or outbound
+messages. It clears channel-process Logger metadata while emitting its record.
+Any failure produces only fixed safe labels or suppresses the record; it never
+falls back to raw values.
+
+Both realtime handlers refuse to start while Phoenix's corresponding default
+logger handler is attached. This prevents an apparently safe handler from
+running beside the raw default logger. Keep `config :phoenix, :logger, false`
+when using any of the Obscura Phoenix loggers.
+
+Phoenix telemetry metadata contains raw socket and channel parameters before
+Obscura receives the event. These handlers protect only the Logger records they
+produce. Other telemetry handlers attached to the same Phoenix events can
+still observe the raw metadata and must be reviewed independently. The
+integration also does not cover LiveView-specific telemetry, custom transport
+instrumentation, channel callback logs, broadcasts, pushes, reverse-proxy
+logs, or arbitrary application logs.

--- a/docs/logger-and-plug.md
+++ b/docs/logger-and-plug.md
@@ -202,11 +202,26 @@ bounded redacted copy can be enabled explicitly:
  handle_in_params: {:redact, entities: [:email, :phone]}}
 ```
 
-The handler never inspects socket assigns, application-private socket data,
-socket identifiers, message references, callback results, or outbound
-messages. It clears channel-process Logger metadata while emitting its record.
-Any failure produces only fixed safe labels or suppresses the record; it never
-falls back to raw values.
+An application may opt in to include one validated UUID-valued socket assign
+as Logger metadata, allowing related channel events to be correlated:
+
+```elixir
+{Obscura.Phoenix.ChannelLogger,
+ topic_patterns: ["room:*"],
+ events: ["new_message"],
+ correlation: {:socket_assign, :chat_id, :uuid}}
+```
+
+The assign is included only for successful joins and handled events, and only
+when it is a canonical UUID string. Missing, malformed, or non-binary values
+are omitted. This supports log correlation only: it does not create spans,
+propagate trace context, or provide distributed tracing. Apart from this opt-in
+field, the handler never inspects socket assigns, application-private socket
+data, socket identifiers, message references, callback results, or outbound
+messages. It clears channel-process Logger metadata while emitting its record
+and then adds only the validated correlation metadata. Any failure produces
+only fixed safe labels or suppresses the record; it never falls back to raw
+values.
 
 Both realtime handlers refuse to start while Phoenix's corresponding default
 logger handler is attached. This prevents an apparently safe handler from

--- a/docs/logger-and-plug.md
+++ b/docs/logger-and-plug.md
@@ -189,8 +189,11 @@ children = [
 The logger emits the matched configured pattern, not the raw topic. Unmatched
 topics become `[FILTERED TOPIC]`, and unconfigured event names become
 `[FILTERED EVENT]`. Oversized topics are filtered before UTF-8 validation or
-pattern matching. Phoenix's internal `"phoenix"` topics remain silent. The
-handler preserves the channel's `:log_join` and `:log_handle_in` levels.
+pattern matching. Configured labels containing control or directional
+formatting codepoints fail startup. Allowed event names are emitted from owned
+startup configuration rather than client-frame binaries. Phoenix's internal
+`"phoenix"` topics remain silent. The handler preserves the channel's
+`:log_join` and `:log_handle_in` levels.
 
 Join and incoming-event parameters are independently omitted by default. A
 bounded redacted copy can be enabled explicitly:
@@ -215,8 +218,8 @@ as Logger metadata, allowing related channel events to be correlated:
 
 The assign name becomes the Logger metadata key. It must be a bounded static
 identifier and must not collide with Logger-reserved metadata such as `:pid`,
-`:gl`, `:time`, or `:domain`. PII-bearing keys are also rejected; invalid keys
-fail startup.
+`:gl`, `:time`, or `:domain`. Keys containing high-confidence PII recognized
+by the `:fast` profile are also rejected; invalid keys fail startup.
 
 The assign is included only for successful joins and handled events, and only
 when it is a canonical UUID string. Missing, malformed, or non-binary values

--- a/docs/logger-and-plug.md
+++ b/docs/logger-and-plug.md
@@ -168,8 +168,11 @@ parameters:
 Realtime parameter redaction accepts only the dependency-light `:fast` profile
 and a narrow set of declarative redaction options. It does not accept
 model-backed profiles, custom recognizers, parser callbacks, or automatic asset
-preparation. Parameter graphs use the same key, byte, node, analysis, and
-numeric limits as request logging and fail closed as `[FILTERED]`.
+preparation. Parameter graphs retain the request logger's structural limits and
+add a stricter 4 KiB ceiling across cumulative key and scalar value text. A
+payload over that realtime analysis ceiling fails closed as `[FILTERED]` before
+PII recognition runs. This bounds work in Phoenix's synchronous telemetry path
+without changing the parameters delivered to the socket or channel.
 
 ## Privacy-safe Phoenix channel logging
 

--- a/docs/logger-and-plug.md
+++ b/docs/logger-and-plug.md
@@ -176,6 +176,12 @@ without changing the parameters delivered to the socket or channel. Structs
 and tuple-bearing terms, including keyword lists, fail closed without invoking
 application protocol implementations.
 
+Phoenix parameter-filter configuration is bounded as part of the same path.
+Discard and keep policies accept at most 256 nonempty parameter names and
+4 KiB of cumulative name text. Keep policies are compiled into map lookups
+before telemetry events are handled. Invalid or oversized filter configuration
+prevents a realtime logger with parameter redaction from starting.
+
 ## Privacy-safe Phoenix channel logging
 
 `Obscura.Phoenix.ChannelLogger` restores channel join and incoming-event logs.

--- a/docs/logger-and-plug.md
+++ b/docs/logger-and-plug.md
@@ -212,16 +212,24 @@ as Logger metadata, allowing related channel events to be correlated:
  correlation: {:socket_assign, :chat_id, :uuid}}
 ```
 
+The assign name becomes the Logger metadata key. It must be a bounded static
+identifier and must not collide with Logger-reserved metadata such as `:pid`,
+`:gl`, `:time`, or `:domain`; invalid keys fail startup.
+
 The assign is included only for successful joins and handled events, and only
 when it is a canonical UUID string. Missing, malformed, or non-binary values
-are omitted. This supports log correlation only: it does not create spans,
-propagate trace context, or provide distributed tracing. Apart from this opt-in
-field, the handler never inspects socket assigns, application-private socket
-data, socket identifiers, message references, callback results, or outbound
-messages. It clears channel-process Logger metadata while emitting its record
-and then adds only the validated correlation metadata. Any failure produces
-only fixed safe labels or suppresses the record; it never falls back to raw
-values.
+are omitted. Phoenix's join telemetry contains the socket from before
+`join/3` runs. The assign must therefore exist before `join/3` to appear on the
+join record. An assign added by `join/3` is available to subsequent handled
+events, but not to that join record.
+
+This supports log correlation only: it does not create spans, propagate trace
+context, or provide distributed tracing. Apart from this opt-in field, the
+handler never inspects socket assigns, application-private socket data, socket
+identifiers, message references, callback results, or outbound messages. It
+clears channel-process Logger metadata while emitting its record and then adds
+only the validated correlation metadata. Any failure produces only fixed safe
+labels or suppresses the record; it never falls back to raw values.
 
 Both realtime handlers refuse to start while Phoenix's corresponding default
 logger handler is attached. This prevents an apparently safe handler from

--- a/docs/logger-and-plug.md
+++ b/docs/logger-and-plug.md
@@ -172,7 +172,9 @@ preparation. Parameter graphs retain the request logger's structural limits and
 add a stricter 4 KiB ceiling across cumulative key and scalar value text. A
 payload over that realtime analysis ceiling fails closed as `[FILTERED]` before
 PII recognition runs. This bounds work in Phoenix's synchronous telemetry path
-without changing the parameters delivered to the socket or channel.
+without changing the parameters delivered to the socket or channel. Structs
+and tuple-bearing terms, including keyword lists, fail closed without invoking
+application protocol implementations.
 
 ## Privacy-safe Phoenix channel logging
 

--- a/docs/logger-and-plug.md
+++ b/docs/logger-and-plug.md
@@ -33,6 +33,13 @@ so do not log it before or after calling the helper.
 
 `Obscura.Phoenix.Plug` depends on Plug, not Phoenix. It can be mounted in Phoenix or any Plug pipeline.
 
+The Plug validates its mode, fields, assign name, telemetry flag, and
+declarative redaction configuration during `init/1`, before the application
+serves requests. Supported fields are `:params` and `:req_headers`; duplicate
+fields are normalized to their first occurrence. Invalid modes, unsupported or
+improper field lists, invalid assign names, and invalid redaction options raise
+an `ArgumentError` during Plug initialization.
+
 Assign mode keeps original request fields and stores redacted copies under `conn.assigns.obscura_redacted`:
 
 ```elixir
@@ -51,7 +58,10 @@ plug Obscura.Phoenix.Plug,
   entities: [:email]
 ```
 
-Supported fields are the connection fields represented by the current Plug helper implementation, with `:params` covered by tests.
+Both supported fields are covered by integration tests. Header assign mode
+stores a redacted map while preserving the original `conn.req_headers` list.
+Replace mode rebuilds the request-header list from that map, so applications
+that depend on duplicate request-header entries should use assign mode.
 
 Assign mode intentionally preserves the original connection fields. Replace
 mode overwrites selected fields in the returned connection, but cannot erase
@@ -72,6 +82,12 @@ parameters:
 ```elixir
 config :phoenix, :logger, false
 ```
+
+The Obscura request logger refuses to start if any corresponding Phoenix HTTP
+logger handler remains attached, including the endpoint-start handler that can
+emit a raw request path. This turns a missing `config :phoenix, :logger, false`
+setting into a startup error instead of allowing raw and sanitized records to
+run side by side.
 
 Mount the plug after `Plug.Parsers` and before the router. Keep assign mode so
 controllers continue to receive the original params:
@@ -247,10 +263,11 @@ clears channel-process Logger metadata while emitting its record and then adds
 only the validated correlation metadata. Any failure produces only fixed safe
 labels or suppresses the record; it never falls back to raw values.
 
-Both realtime handlers refuse to start while Phoenix's corresponding default
-logger handler is attached. This prevents an apparently safe handler from
-running beside the raw default logger. Keep `config :phoenix, :logger, false`
-when using any of the Obscura Phoenix loggers.
+All three Phoenix handlers refuse to start while Phoenix's corresponding
+default logger handler is attached. This prevents an apparently safe handler
+from running beside the raw default logger. Keep
+`config :phoenix, :logger, false` when using any of the Obscura Phoenix
+loggers.
 
 Phoenix telemetry metadata contains raw socket and channel parameters before
 Obscura receives the event. These handlers protect only the Logger records they

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -351,14 +351,17 @@ or `{:redact, keyword()}`), `:name`, and `:inspect_opts`.
 `{:socket_assign, atom(), :uuid}`). A configured correlation assign is emitted
 as Logger metadata only for successful joins and handled events when its value
 is a valid UUID string, allowing related channel events to be correlated.
-Correlation assign names must be bounded, PII-free static identifiers and
-cannot use Logger-reserved metadata keys. Phoenix join telemetry exposes the
+Correlation assign names must be bounded static identifiers, cannot use
+Logger-reserved metadata keys, and cannot contain high-confidence PII
+recognized by the `:fast` profile. Phoenix join telemetry exposes the
 pre-`join/3` socket, so an assign created by `join/3` is available to subsequent
 handled events but not to that join record. This is log correlation metadata,
 not distributed tracing or trace-context propagation. Realtime redaction is
 restricted to `:fast` and the declarative `:entities` and `:max_depth` options.
 Unknown options fail startup. Raw topics and event names are never logged: only
-configured topic patterns and allow-listed event names are emitted. Oversized
+configured topic patterns and allow-listed event names are emitted. Configured
+labels containing control or directional formatting codepoints fail startup,
+and emitted event labels come from owned startup configuration. Oversized
 topics fail closed before content validation. Both handlers reject startup
 while the corresponding Phoenix default logger handler remains attached.
 

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -364,6 +364,9 @@ and scalar value text; payloads over that ceiling become `[FILTERED]` before
 PII recognition. Structs and tuple-bearing terms, including keyword lists, fail
 closed without protocol dispatch. Raw topics and event names are never logged:
 only configured topic patterns and allow-listed event names are emitted.
+Phoenix discard and keep filter configuration is limited to 256 nonempty
+parameter names and 4 KiB of cumulative name text; keep names are compiled into
+map lookups before realtime events are handled.
 Configured labels containing control or directional formatting codepoints fail
 startup, and emitted event labels come from owned startup configuration.
 Oversized topics fail closed before content validation. Both handlers reject

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -347,9 +347,14 @@ or `{:redact, keyword()}`), `:name`, and `:inspect_opts`.
 `Obscura.Phoenix.ChannelLogger` supports `:topic_patterns` and `:events`
 (proper lists of bounded static strings), `:join_params` and
 `:handle_in_params` (`:omit` by default, or `{:redact, keyword()}`), `:name`,
-and `:inspect_opts`. Realtime redaction is restricted to `:fast` and the
-declarative `:entities` and `:max_depth` options. Unknown options fail startup.
-Raw topics and event names are never logged: only configured topic patterns and
+`:inspect_opts`, and `:correlation` (`:omit` by default, or
+`{:socket_assign, atom(), :uuid}`). A configured correlation assign is emitted
+as Logger metadata only for successful joins and handled events when its value
+is a valid UUID string, allowing related channel events to be correlated. This
+is log correlation metadata, not distributed tracing or trace-context
+propagation. Realtime redaction is restricted to `:fast` and the declarative
+`:entities` and `:max_depth` options. Unknown options fail startup. Raw topics
+and event names are never logged: only configured topic patterns and
 allow-listed event names are emitted. Both handlers reject startup while the
 corresponding Phoenix default logger handler remains attached.
 

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -358,12 +358,15 @@ pre-`join/3` socket, so an assign created by `join/3` is available to subsequent
 handled events but not to that join record. This is log correlation metadata,
 not distributed tracing or trace-context propagation. Realtime redaction is
 restricted to `:fast` and the declarative `:entities` and `:max_depth` options.
-Unknown options fail startup. Raw topics and event names are never logged: only
-configured topic patterns and allow-listed event names are emitted. Configured
-labels containing control or directional formatting codepoints fail startup,
-and emitted event labels come from owned startup configuration. Oversized
-topics fail closed before content validation. Both handlers reject startup
-while the corresponding Phoenix default logger handler remains attached.
+Unknown options fail startup. Realtime parameter graphs retain the request
+logger's structural limits and add a fixed 4 KiB ceiling across cumulative key
+and scalar value text; payloads over that ceiling become `[FILTERED]` before
+PII recognition. Raw topics and event names are never logged: only configured
+topic patterns and allow-listed event names are emitted. Configured labels
+containing control or directional formatting codepoints fail startup, and
+emitted event labels come from owned startup configuration. Oversized topics
+fail closed before content validation. Both handlers reject startup while the
+corresponding Phoenix default logger handler remains attached.
 
 ## Optional Dependencies And Assets
 

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -351,16 +351,16 @@ or `{:redact, keyword()}`), `:name`, and `:inspect_opts`.
 `{:socket_assign, atom(), :uuid}`). A configured correlation assign is emitted
 as Logger metadata only for successful joins and handled events when its value
 is a valid UUID string, allowing related channel events to be correlated.
-Correlation assign names must be bounded static identifiers and cannot use
-Logger-reserved metadata keys. Phoenix join telemetry exposes the pre-`join/3`
-socket, so an assign created by `join/3` is available to subsequent handled
-events but not to that join record. This is log correlation metadata, not
-distributed tracing or trace-context propagation. Realtime redaction is
+Correlation assign names must be bounded, PII-free static identifiers and
+cannot use Logger-reserved metadata keys. Phoenix join telemetry exposes the
+pre-`join/3` socket, so an assign created by `join/3` is available to subsequent
+handled events but not to that join record. This is log correlation metadata,
+not distributed tracing or trace-context propagation. Realtime redaction is
 restricted to `:fast` and the declarative `:entities` and `:max_depth` options.
 Unknown options fail startup. Raw topics and event names are never logged: only
-configured topic patterns and allow-listed event names are emitted. Both
-handlers reject startup while the corresponding Phoenix default logger handler
-remains attached.
+configured topic patterns and allow-listed event names are emitted. Oversized
+topics fail closed before content validation. Both handlers reject startup
+while the corresponding Phoenix default logger handler remains attached.
 
 ## Optional Dependencies And Assets
 

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -317,7 +317,10 @@ Streaming rehydration requires `:vault` and supports `:token_prefix`,
 
 The Plug supports `:fields` (`[:params]`), `:mode` (`:assign_redacted`,
 `:replace`, or `:disabled`), `:assign` (`:obscura_redacted`), and supported
-redaction options. Other values are outside the stable schema.
+redaction options. Supported fields are `:params` and `:req_headers`.
+`init/1` validates and normalizes these integration options, removes duplicate
+fields after their first occurrence, and raises `ArgumentError` for invalid
+configuration before requests run. Other values are outside the stable schema.
 
 `Obscura.Phoenix.Logger` supports `:assign` (atom, default
 `:obscura_redacted`), `:name` (GenServer name, default
@@ -340,7 +343,9 @@ reason or detaching the handler. The logger applies Phoenix's configured
 containing high-confidence `:fast` profile PII before inspection. Bare domains
 are excluded from key recognition because ordinary dotted field names are
 ambiguous; applications can filter specific dotted keys through Phoenix's
-policy.
+policy. The request logger rejects startup while a corresponding Phoenix
+default HTTP logger remains attached, including the endpoint-start logger that
+can emit raw request paths.
 
 `Obscura.Phoenix.SocketLogger` supports `:connect_params` (`:omit` by default,
 or `{:redact, keyword()}`), `:name`, and `:inspect_opts`.

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -361,12 +361,14 @@ restricted to `:fast` and the declarative `:entities` and `:max_depth` options.
 Unknown options fail startup. Realtime parameter graphs retain the request
 logger's structural limits and add a fixed 4 KiB ceiling across cumulative key
 and scalar value text; payloads over that ceiling become `[FILTERED]` before
-PII recognition. Raw topics and event names are never logged: only configured
-topic patterns and allow-listed event names are emitted. Configured labels
-containing control or directional formatting codepoints fail startup, and
-emitted event labels come from owned startup configuration. Oversized topics
-fail closed before content validation. Both handlers reject startup while the
-corresponding Phoenix default logger handler remains attached.
+PII recognition. Structs and tuple-bearing terms, including keyword lists, fail
+closed without protocol dispatch. Raw topics and event names are never logged:
+only configured topic patterns and allow-listed event names are emitted.
+Configured labels containing control or directional formatting codepoints fail
+startup, and emitted event labels come from owned startup configuration.
+Oversized topics fail closed before content validation. Both handlers reject
+startup while the corresponding Phoenix default logger handler remains
+attached.
 
 ## Optional Dependencies And Assets
 

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -342,6 +342,17 @@ are excluded from key recognition because ordinary dotted field names are
 ambiguous; applications can filter specific dotted keys through Phoenix's
 policy.
 
+`Obscura.Phoenix.SocketLogger` supports `:connect_params` (`:omit` by default,
+or `{:redact, keyword()}`), `:name`, and `:inspect_opts`.
+`Obscura.Phoenix.ChannelLogger` supports `:topic_patterns` and `:events`
+(proper lists of bounded static strings), `:join_params` and
+`:handle_in_params` (`:omit` by default, or `{:redact, keyword()}`), `:name`,
+and `:inspect_opts`. Realtime redaction is restricted to `:fast` and the
+declarative `:entities` and `:max_depth` options. Unknown options fail startup.
+Raw topics and event names are never logged: only configured topic patterns and
+allow-listed event names are emitted. Both handlers reject startup while the
+corresponding Phoenix default logger handler remains attached.
+
 ## Optional Dependencies And Assets
 
 The package's required runtime dependencies are Jason, Telemetry, and Plug.

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -350,13 +350,17 @@ or `{:redact, keyword()}`), `:name`, and `:inspect_opts`.
 `:inspect_opts`, and `:correlation` (`:omit` by default, or
 `{:socket_assign, atom(), :uuid}`). A configured correlation assign is emitted
 as Logger metadata only for successful joins and handled events when its value
-is a valid UUID string, allowing related channel events to be correlated. This
-is log correlation metadata, not distributed tracing or trace-context
-propagation. Realtime redaction is restricted to `:fast` and the declarative
-`:entities` and `:max_depth` options. Unknown options fail startup. Raw topics
-and event names are never logged: only configured topic patterns and
-allow-listed event names are emitted. Both handlers reject startup while the
-corresponding Phoenix default logger handler remains attached.
+is a valid UUID string, allowing related channel events to be correlated.
+Correlation assign names must be bounded static identifiers and cannot use
+Logger-reserved metadata keys. Phoenix join telemetry exposes the pre-`join/3`
+socket, so an assign created by `join/3` is available to subsequent handled
+events but not to that join record. This is log correlation metadata, not
+distributed tracing or trace-context propagation. Realtime redaction is
+restricted to `:fast` and the declarative `:entities` and `:max_depth` options.
+Unknown options fail startup. Raw topics and event names are never logged: only
+configured topic patterns and allow-listed event names are emitted. Both
+handlers reject startup while the corresponding Phoenix default logger handler
+remains attached.
 
 ## Optional Dependencies And Assets
 

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -105,12 +105,15 @@ information, application-private socket data, identifiers, message references,
 callback results are never inspected. Raw unmatched topics and event names are
 never emitted. The channel logger may inspect exactly one explicitly configured
 socket assign for log correlation. It emits that assign only when its value is
-a valid UUID and its name is a bounded, PII-free, non-reserved Logger metadata
-key. Oversized raw topics fail closed before UTF-8 validation or pattern
-matching. Correlation UUIDs can still identify sessions or workflows, so
-deployers remain responsible for access control, retention, and downstream log
-handling. Logger metadata inherited from request, socket, or channel processes
-is excluded from Obscura's records.
+a valid UUID and its name is a bounded, non-reserved Logger metadata key that
+does not contain high-confidence PII recognized by the `:fast` profile.
+Configured labels containing control or directional formatting codepoints fail
+startup. Allowed event labels are emitted from owned startup configuration,
+not client-frame binaries. Oversized raw topics fail closed before UTF-8
+validation or pattern matching. Correlation UUIDs can still identify sessions
+or workflows, so deployers remain responsible for access control, retention,
+and downstream log handling. Logger metadata inherited from request, socket,
+or channel processes is excluded from Obscura's records.
 
 Phoenix emits raw connection and channel parameters in telemetry metadata.
 Obscura's handlers sanitize only their own Logger output and cannot prevent

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -100,11 +100,16 @@ caller's original structures unless the caller replaces or discards it.
 
 The Phoenix request logger consumes only a pre-redacted Plug assign. The
 Phoenix socket and channel loggers omit parameters by default; explicit
-realtime inclusion is limited to bounded `:fast` redaction. They never inspect
-socket connection information, assigns, application-private socket data,
-identifiers, message references, callback results, or raw unmatched topics and
-event names. Logger metadata inherited from request, socket, or channel
-processes is excluded from Obscura's records.
+realtime inclusion is limited to bounded `:fast` redaction. Socket connection
+information, application-private socket data, identifiers, message references,
+callback results, and raw unmatched topics and event names are never inspected.
+The channel logger may inspect exactly one explicitly configured socket assign
+for log correlation. It emits that assign only when its value is a valid UUID
+and its name is a bounded, non-reserved Logger metadata key. Correlation UUIDs
+can still identify sessions or workflows, so deployers remain responsible for
+access control, retention, and downstream log handling. Logger metadata
+inherited from request, socket, or channel processes is excluded from
+Obscura's records.
 
 Phoenix emits raw connection and channel parameters in telemetry metadata.
 Obscura's handlers sanitize only their own Logger output and cannot prevent

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -102,14 +102,15 @@ The Phoenix request logger consumes only a pre-redacted Plug assign. The
 Phoenix socket and channel loggers omit parameters by default; explicit
 realtime inclusion is limited to bounded `:fast` redaction. Socket connection
 information, application-private socket data, identifiers, message references,
-callback results, and raw unmatched topics and event names are never inspected.
-The channel logger may inspect exactly one explicitly configured socket assign
-for log correlation. It emits that assign only when its value is a valid UUID
-and its name is a bounded, non-reserved Logger metadata key. Correlation UUIDs
-can still identify sessions or workflows, so deployers remain responsible for
-access control, retention, and downstream log handling. Logger metadata
-inherited from request, socket, or channel processes is excluded from
-Obscura's records.
+callback results are never inspected. Raw unmatched topics and event names are
+never emitted. The channel logger may inspect exactly one explicitly configured
+socket assign for log correlation. It emits that assign only when its value is
+a valid UUID and its name is a bounded, PII-free, non-reserved Logger metadata
+key. Oversized raw topics fail closed before UTF-8 validation or pattern
+matching. Correlation UUIDs can still identify sessions or workflows, so
+deployers remain responsible for access control, retention, and downstream log
+handling. Logger metadata inherited from request, socket, or channel processes
+is excluded from Obscura's records.
 
 Phoenix emits raw connection and channel parameters in telemetry metadata.
 Obscura's handlers sanitize only their own Logger output and cannot prevent

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -98,6 +98,21 @@ field policies detect the values. They do not make arbitrary terms
 non-sensitive. Plug and LLM helpers retain raw request/message data in the
 caller's original structures unless the caller replaces or discards it.
 
+The Phoenix request logger consumes only a pre-redacted Plug assign. The
+Phoenix socket and channel loggers omit parameters by default; explicit
+realtime inclusion is limited to bounded `:fast` redaction. They never inspect
+socket connection information, assigns, application-private socket data,
+identifiers, message references, callback results, or raw unmatched topics and
+event names. Logger metadata inherited from request, socket, or channel
+processes is excluded from Obscura's records.
+
+Phoenix emits raw connection and channel parameters in telemetry metadata.
+Obscura's handlers sanitize only their own Logger output and cannot prevent
+another telemetry handler from observing the original event. Deployers must
+review every handler attached to Phoenix socket and channel events. Outbound
+channel traffic, LiveView-specific telemetry, reverse proxies, transports, and
+application-authored logs remain separate boundaries.
+
 ### Vaults And Rehydration
 
 Memory and ETS vaults store raw values for reversible pseudonymization. Memory

--- a/lib/obscura/internal/phoenix_log.ex
+++ b/lib/obscura/internal/phoenix_log.ex
@@ -328,6 +328,7 @@ defmodule Obscura.Internal.PhoenixLog do
   @spec log_level(term(), Logger.level()) :: Logger.level() | false
   def log_level(false, _default), do: false
   def log_level(nil, default), do: default
+  def log_level(:warn, _default), do: :warning
   def log_level(level, _default) when level in @levels, do: level
   def log_level(_level, _default), do: false
 
@@ -717,10 +718,16 @@ defmodule Obscura.Internal.PhoenixLog do
     end
   end
 
-  defp consume_parameter_term(value, budget, _mode) when is_binary(value) do
+  defp consume_parameter_term(value, budget, :realtime) when is_binary(value) do
     with {:ok, budget} <- consume_parameter_node(budget),
          {:ok, budget} <- consume_parameter_value(byte_size(value), budget) do
       consume_parameter_analysis(budget)
+    end
+  end
+
+  defp consume_parameter_term(value, budget, _mode) when is_binary(value) do
+    with {:ok, budget} <- consume_parameter_node(budget) do
+      consume_parameter_value(byte_size(value), budget)
     end
   end
 

--- a/lib/obscura/internal/phoenix_log.ex
+++ b/lib/obscura/internal/phoenix_log.ex
@@ -15,6 +15,7 @@ defmodule Obscura.Internal.PhoenixLog do
   @max_parameter_nodes 1_024
   @max_parameter_value_bytes 65_536
   @max_parameter_analysis_terms 128
+  @max_realtime_parameter_analysis_bytes 4_096
   @max_numeric_digits 64
   @max_numeric_magnitude Integer.pow(10, @max_numeric_digits)
 
@@ -160,10 +161,10 @@ defmodule Obscura.Internal.PhoenixLog do
   def render_params(_params, %{mode: :omit}), do: @omitted
 
   def render_params(params, %{mode: :redact} = policy) do
-    with true <- parameter_budget_safe?(params),
+    with true <- realtime_parameter_budget_safe?(params),
          filtered <- apply_parameter_filter(params, policy.filter),
          {:ok, result} <- Obscura.Structured.redact(filtered, policy.redaction_opts),
-         true <- parameter_budget_safe?(result.data) do
+         true <- realtime_parameter_budget_safe?(result.data) do
       result.data
       |> log_safe_term(policy.key_entities)
       |> inspect(policy.inspect_opts)
@@ -671,6 +672,16 @@ defmodule Obscura.Internal.PhoenixLog do
 
   defp parameter_budget_safe?(params) do
     match?({:ok, _budget}, consume_parameter_term(params, {0, 0, 0, 0, 0}))
+  end
+
+  defp realtime_parameter_budget_safe?(params) do
+    case consume_parameter_term(params, {0, 0, 0, 0, 0}) do
+      {:ok, {_nodes, _keys, key_bytes, value_bytes, _analysis_terms}} ->
+        key_bytes + value_bytes <= @max_realtime_parameter_analysis_bytes
+
+      :error ->
+        false
+    end
   end
 
   defp consume_parameter_term(_term, {nodes, keys, key_bytes, value_bytes, analysis_terms})

--- a/lib/obscura/internal/phoenix_log.ex
+++ b/lib/obscura/internal/phoenix_log.ex
@@ -29,6 +29,26 @@ defmodule Obscura.Internal.PhoenixLog do
 
   @levels [:debug, :info, :notice, :warning, :error, :critical, :alert, :emergency]
 
+  @reserved_logger_metadata_keys [
+    :application,
+    :crash_reason,
+    :domain,
+    :erl_level,
+    :error_logger,
+    :file,
+    :function,
+    :gl,
+    :initial_call,
+    :line,
+    :logger_formatter,
+    :mfa,
+    :module,
+    :pid,
+    :registered_name,
+    :report_cb,
+    :time
+  ]
+
   @redaction_options [:entities, :max_depth]
 
   @type params_policy :: %{mode: :omit} | map()
@@ -455,9 +475,10 @@ defmodule Obscura.Internal.PhoenixLog do
   defp identifier_bytes?(_text), do: false
 
   defp safe_correlation_key?(key) do
-    key
-    |> Atom.to_string()
-    |> identifier_text?()
+    text = Atom.to_string(key)
+
+    byte_size(text) <= @max_identifier_bytes and identifier_text?(text) and
+      key not in @reserved_logger_metadata_keys
   end
 
   defp uuid?(

--- a/lib/obscura/internal/phoenix_log.ex
+++ b/lib/obscura/internal/phoenix_log.ex
@@ -32,6 +32,9 @@ defmodule Obscura.Internal.PhoenixLog do
   @redaction_options [:entities, :max_depth]
 
   @type params_policy :: %{mode: :omit} | map()
+  @type correlation_policy ::
+          %{mode: :omit}
+          | %{mode: :socket_assign, assign: atom(), metadata_key: atom(), format: :uuid}
 
   @spec filtered() :: String.t()
   def filtered, do: @filtered
@@ -204,6 +207,42 @@ defmodule Obscura.Internal.PhoenixLog do
 
   def safe_topic(_topic, _patterns), do: @filtered_topic
 
+  @spec prepare_correlation(term()) :: {:ok, correlation_policy()} | {:error, term()}
+  def prepare_correlation(:omit), do: {:ok, %{mode: :omit}}
+
+  def prepare_correlation({:socket_assign, assign, :uuid})
+      when is_atom(assign) and not is_nil(assign) do
+    if safe_correlation_key?(assign) do
+      {:ok, %{mode: :socket_assign, assign: assign, metadata_key: assign, format: :uuid}}
+    else
+      invalid_option(:correlation, :invalid_metadata_key)
+    end
+  end
+
+  def prepare_correlation(_correlation),
+    do: invalid_option(:correlation, :expected_omit_or_socket_assign)
+
+  @spec correlation_metadata(term(), correlation_policy(), boolean()) :: keyword()
+  def correlation_metadata(_socket, _policy, false), do: []
+  def correlation_metadata(_socket, %{mode: :omit}, true), do: []
+
+  def correlation_metadata(
+        %{assigns: assigns},
+        %{mode: :socket_assign, assign: assign, metadata_key: metadata_key, format: :uuid},
+        true
+      )
+      when is_map(assigns) do
+    case Map.get(assigns, assign) do
+      value when is_binary(value) ->
+        if uuid?(value), do: [{metadata_key, value}], else: []
+
+      _value ->
+        []
+    end
+  end
+
+  def correlation_metadata(_socket, _policy, true), do: []
+
   @spec prepare_events(term()) :: {:ok, MapSet.t(String.t())} | {:error, term()}
   def prepare_events(events) when is_list(events) do
     with :ok <- validate_bounded_list(events, @max_events, :events) do
@@ -264,20 +303,24 @@ defmodule Obscura.Internal.PhoenixLog do
   def log_level(_level, _default), do: false
 
   @spec log(Logger.level() | false, (-> iodata())) :: :ok
-  def log(false, _message), do: :ok
+  def log(level, message), do: log(level, message, [])
 
-  def log(level, message) when level in @levels and is_function(message, 0) do
+  @spec log(Logger.level() | false, (-> iodata()), keyword()) :: :ok
+  def log(false, _message, _metadata), do: :ok
+
+  def log(level, message, safe_metadata)
+      when level in @levels and is_function(message, 0) and is_list(safe_metadata) do
     metadata = Logger.metadata()
     Logger.reset_metadata()
 
     try do
-      Logger.log(level, message)
+      Logger.log(level, message, safe_metadata)
     after
       Logger.reset_metadata(metadata)
     end
   end
 
-  def log(_level, _message), do: :ok
+  def log(_level, _message, _metadata), do: :ok
 
   @spec phoenix_logger_attached?([atom()]) :: boolean()
   def phoenix_logger_attached?(event) do
@@ -410,6 +453,30 @@ defmodule Obscura.Internal.PhoenixLog do
        do: identifier_bytes?(rest)
 
   defp identifier_bytes?(_text), do: false
+
+  defp safe_correlation_key?(key) do
+    key
+    |> Atom.to_string()
+    |> identifier_text?()
+  end
+
+  defp uuid?(
+         <<part1::binary-size(8), "-", part2::binary-size(4), "-", part3::binary-size(4), "-",
+           part4::binary-size(4), "-", part5::binary-size(12)>>
+       ) do
+    Enum.all?([part1, part2, part3, part4, part5], &hex?/1)
+  end
+
+  defp uuid?(_value), do: false
+
+  defp hex?(value), do: hex_bytes?(value)
+  defp hex_bytes?(<<>>), do: true
+
+  defp hex_bytes?(<<byte, rest::binary>>)
+       when byte in ?0..?9 or byte in ?A..?F or byte in ?a..?f,
+       do: hex_bytes?(rest)
+
+  defp hex_bytes?(_value), do: false
 
   defp label_contains_pii?(label) do
     case key_entities() do

--- a/lib/obscura/internal/phoenix_log.ex
+++ b/lib/obscura/internal/phoenix_log.ex
@@ -401,7 +401,8 @@ defmodule Obscura.Internal.PhoenixLog do
 
   defp compile_topic_pattern(pattern) do
     if safe_static_label?(pattern) do
-      compile_valid_topic_pattern(pattern, :binary.matches(pattern, "*"))
+      owned_pattern = :binary.copy(pattern)
+      compile_valid_topic_pattern(owned_pattern, :binary.matches(owned_pattern, "*"))
     else
       invalid_option(:topic_patterns, :invalid_pattern)
     end
@@ -541,10 +542,16 @@ defmodule Obscura.Internal.PhoenixLog do
        when is_list(parameters) or is_binary(parameters) do
     parameters = List.wrap(parameters)
 
-    if Enum.all?(parameters, &is_binary/1) do
-      key_match = :binary.compile_pattern(parameters)
-      value_match = parameters |> Enum.map(&(&1 <> "=")) |> :binary.compile_pattern()
-      {:ok, {:compiled, key_match, value_match}}
+    if Enum.all?(parameters, &(is_binary(&1) and byte_size(&1) > 0)) do
+      try do
+        key_match = :binary.compile_pattern(parameters)
+        value_match = parameters |> Enum.map(&(&1 <> "=")) |> :binary.compile_pattern()
+        {:ok, {:compiled, key_match, value_match}}
+      rescue
+        _error -> invalid_option(:filter_parameters, :invalid_phoenix_configuration)
+      catch
+        _kind, _reason -> invalid_option(:filter_parameters, :invalid_phoenix_configuration)
+      end
     else
       invalid_option(:filter_parameters, :invalid_phoenix_configuration)
     end
@@ -743,7 +750,7 @@ defmodule Obscura.Internal.PhoenixLog do
   defp consume_parameter_term(_term, budget, _mode), do: consume_parameter_node(budget)
 
   defp consume_parameter_entry({key, value}, {:ok, budget}, mode) do
-    with {:ok, budget} <- consume_parameter_key(key, budget),
+    with {:ok, budget} <- consume_parameter_key(key, budget, mode),
          {:ok, budget} <- consume_parameter_term(value, budget, mode) do
       {:cont, {:ok, budget}}
     else
@@ -776,7 +783,15 @@ defmodule Obscura.Internal.PhoenixLog do
     if elem(budget, 0) > @max_parameter_nodes, do: :error, else: {:ok, budget}
   end
 
-  defp consume_parameter_key(key, {nodes, keys, key_bytes, value_bytes, analysis_terms}) do
+  defp consume_parameter_key(key, _budget, :realtime)
+       when not is_binary(key) and not is_atom(key) and not is_number(key),
+       do: :error
+
+  defp consume_parameter_key(
+         key,
+         {nodes, keys, key_bytes, value_bytes, analysis_terms},
+         _mode
+       ) do
     with {:ok, size} <- bounded_key_size(key) do
       budget = {nodes, keys + 1, key_bytes + size, value_bytes, analysis_terms}
 

--- a/lib/obscura/internal/phoenix_log.ex
+++ b/lib/obscura/internal/phoenix_log.ex
@@ -477,8 +477,11 @@ defmodule Obscura.Internal.PhoenixLog do
 
   defp safe_static_label?(_label), do: false
 
-  defp identifier_text?(<<>>), do: false
-  defp identifier_text?(text), do: identifier_bytes?(text)
+  defp identifier_text?(<<first, rest::binary>>)
+       when first in ?A..?Z or first in ?a..?z or first == ?_,
+       do: identifier_bytes?(rest)
+
+  defp identifier_text?(_text), do: false
   defp identifier_bytes?(<<>>), do: true
 
   defp identifier_bytes?(<<byte, rest::binary>>)

--- a/lib/obscura/internal/phoenix_log.ex
+++ b/lib/obscura/internal/phoenix_log.ex
@@ -21,9 +21,12 @@ defmodule Obscura.Internal.PhoenixLog do
 
   @max_patterns 64
   @max_events 128
+  @max_filter_parameters 256
+  @max_filter_parameter_bytes 4_096
   @max_label_bytes 128
   @max_topic_bytes 4_096
   @max_identifier_bytes 255
+  @max_identifier_digits 6
   @max_method_bytes 32
   @max_measurement 9_223_372_036_854_775_807
 
@@ -461,13 +464,19 @@ defmodule Obscura.Internal.PhoenixLog do
     end)
   end
 
-  defp validate_bounded_list(values, maximum, option) do
-    cond do
-      List.improper?(values) -> invalid_option(option, :expected_proper_list)
-      Enum.count_until(values, maximum + 1) > maximum -> invalid_option(option, :too_many_values)
-      true -> :ok
-    end
-  end
+  defp validate_bounded_list(values, maximum, option),
+    do: validate_bounded_list(values, maximum, option, 0)
+
+  defp validate_bounded_list([], _maximum, _option, _count), do: :ok
+
+  defp validate_bounded_list([_value | _rest], maximum, option, maximum),
+    do: invalid_option(option, :too_many_values)
+
+  defp validate_bounded_list([_value | rest], maximum, option, count),
+    do: validate_bounded_list(rest, maximum, option, count + 1)
+
+  defp validate_bounded_list(_improper, _maximum, option, _count),
+    do: invalid_option(option, :expected_proper_list)
 
   defp safe_static_label?(label) when is_binary(label) do
     byte_size(label) > 0 and byte_size(label) <= @max_label_bytes and
@@ -477,18 +486,44 @@ defmodule Obscura.Internal.PhoenixLog do
 
   defp safe_static_label?(_label), do: false
 
-  defp identifier_text?(<<first, rest::binary>>)
+  defp identifier_text?(<<"Elixir.", rest::binary>>), do: module_identifier?(rest, 0)
+  defp identifier_text?(text), do: simple_identifier?(text, 0)
+
+  defp simple_identifier?(<<first, rest::binary>>, digits)
        when first in ?A..?Z or first in ?a..?z or first == ?_,
-       do: identifier_bytes?(rest)
+       do: simple_identifier_tail?(rest, digits)
 
-  defp identifier_text?(_text), do: false
-  defp identifier_bytes?(<<>>), do: true
+  defp simple_identifier?(_text, _digits), do: false
+  defp simple_identifier_tail?(<<>>, _digits), do: true
 
-  defp identifier_bytes?(<<byte, rest::binary>>)
-       when byte in ?0..?9 or byte in ?A..?Z or byte in ?a..?z or byte in [?_, ?., ?:, ?-],
-       do: identifier_bytes?(rest)
+  defp simple_identifier_tail?(<<byte, rest::binary>>, digits)
+       when byte in ?A..?Z or byte in ?a..?z or byte == ?_,
+       do: simple_identifier_tail?(rest, digits)
 
-  defp identifier_bytes?(_text), do: false
+  defp simple_identifier_tail?(<<byte, rest::binary>>, digits)
+       when byte in ?0..?9 and digits < @max_identifier_digits,
+       do: simple_identifier_tail?(rest, digits + 1)
+
+  defp simple_identifier_tail?(_text, _digits), do: false
+
+  defp module_identifier?(<<first, rest::binary>>, digits) when first in ?A..?Z,
+    do: module_segment_tail?(rest, digits)
+
+  defp module_identifier?(_text, _digits), do: false
+  defp module_segment_tail?(<<>>, _digits), do: true
+
+  defp module_segment_tail?(<<?., rest::binary>>, digits),
+    do: module_identifier?(rest, digits)
+
+  defp module_segment_tail?(<<byte, rest::binary>>, digits)
+       when byte in ?A..?Z or byte in ?a..?z or byte == ?_,
+       do: module_segment_tail?(rest, digits)
+
+  defp module_segment_tail?(<<byte, rest::binary>>, digits)
+       when byte in ?0..?9 and digits < @max_identifier_digits,
+       do: module_segment_tail?(rest, digits + 1)
+
+  defp module_segment_tail?(_text, _digits), do: false
 
   defp safe_correlation_key?(key) do
     text = Atom.to_string(key)
@@ -536,8 +571,11 @@ defmodule Obscura.Internal.PhoenixLog do
   defp compile_parameter_filter({:discard, parameters}),
     do: compile_parameter_filter(parameters)
 
-  defp compile_parameter_filter({:keep, parameters}) when is_list(parameters),
-    do: {:ok, {:keep, parameters}}
+  defp compile_parameter_filter({:keep, parameters}) when is_list(parameters) do
+    with :ok <- validate_filter_parameters(parameters) do
+      {:ok, {:keep, Map.new(parameters, &{&1, true})}}
+    end
+  end
 
   defp compile_parameter_filter([]), do: {:ok, {:compiled, [], []}}
 
@@ -545,7 +583,7 @@ defmodule Obscura.Internal.PhoenixLog do
        when is_list(parameters) or is_binary(parameters) do
     parameters = List.wrap(parameters)
 
-    if Enum.all?(parameters, &(is_binary(&1) and byte_size(&1) > 0)) do
+    with :ok <- validate_filter_parameters(parameters) do
       try do
         key_match = :binary.compile_pattern(parameters)
         value_match = parameters |> Enum.map(&(&1 <> "=")) |> :binary.compile_pattern()
@@ -555,12 +593,28 @@ defmodule Obscura.Internal.PhoenixLog do
       catch
         _kind, _reason -> invalid_option(:filter_parameters, :invalid_phoenix_configuration)
       end
-    else
-      invalid_option(:filter_parameters, :invalid_phoenix_configuration)
     end
   end
 
   defp compile_parameter_filter(_parameters),
+    do: invalid_option(:filter_parameters, :invalid_phoenix_configuration)
+
+  defp validate_filter_parameters(parameters),
+    do: validate_filter_parameters(parameters, 0, 0)
+
+  defp validate_filter_parameters([], _count, _bytes), do: :ok
+
+  defp validate_filter_parameters([parameter | rest], count, bytes)
+       when is_binary(parameter) and byte_size(parameter) > 0 do
+    count = count + 1
+    bytes = bytes + byte_size(parameter)
+
+    if count <= @max_filter_parameters and bytes <= @max_filter_parameter_bytes,
+      do: validate_filter_parameters(rest, count, bytes),
+      else: invalid_option(:filter_parameters, :invalid_phoenix_configuration)
+  end
+
+  defp validate_filter_parameters(_invalid, _count, _bytes),
     do: invalid_option(:filter_parameters, :invalid_phoenix_configuration)
 
   defp apply_parameter_filter(values, {:compiled, key_match, value_match}),
@@ -603,7 +657,7 @@ defmodule Obscura.Internal.PhoenixLog do
 
   defp keep_parameter_values(map, parameters) when is_map(map) do
     Map.new(map, fn {key, value} ->
-      if is_binary(key) and key in parameters do
+      if is_binary(key) and Map.has_key?(parameters, key) do
         {key, value}
       else
         {key, keep_parameter_values(value, parameters)}

--- a/lib/obscura/internal/phoenix_log.ex
+++ b/lib/obscura/internal/phoenix_log.ex
@@ -132,7 +132,8 @@ defmodule Obscura.Internal.PhoenixLog do
            |> Keyword.put(:profile, :fast)
            |> Keyword.put(:telemetry, false)
            |> Keyword.put(:include_text, false)
-           |> Keyword.put(:traverse_structs, false),
+           |> Keyword.put(:traverse_structs, false)
+           |> Keyword.put(:skip_protocol, true),
          {:ok, _probe} <- Obscura.Structured.redact(%{"sample" => "safe"}, redaction_opts) do
       {:ok,
        %{
@@ -671,11 +672,11 @@ defmodule Obscura.Internal.PhoenixLog do
   defp filtered_key(index), do: @filtered_key_prefix <> Integer.to_string(index) <> "]"
 
   defp parameter_budget_safe?(params) do
-    match?({:ok, _budget}, consume_parameter_term(params, {0, 0, 0, 0, 0}))
+    match?({:ok, _budget}, consume_parameter_term(params, {0, 0, 0, 0, 0}, :standard))
   end
 
   defp realtime_parameter_budget_safe?(params) do
-    case consume_parameter_term(params, {0, 0, 0, 0, 0}) do
+    case consume_parameter_term(params, {0, 0, 0, 0, 0}, :realtime) do
       {:ok, {_nodes, _keys, key_bytes, value_bytes, _analysis_terms}} ->
         key_bytes + value_bytes <= @max_realtime_parameter_analysis_bytes
 
@@ -684,40 +685,46 @@ defmodule Obscura.Internal.PhoenixLog do
     end
   end
 
-  defp consume_parameter_term(_term, {nodes, keys, key_bytes, value_bytes, analysis_terms})
+  defp consume_parameter_term(
+         _term,
+         {nodes, keys, key_bytes, value_bytes, analysis_terms},
+         _mode
+       )
        when nodes >= @max_parameter_nodes or keys > @max_parameter_keys or
               key_bytes > @max_parameter_key_bytes or
               value_bytes > @max_parameter_value_bytes or
               analysis_terms > @max_parameter_analysis_terms,
        do: :error
 
-  defp consume_parameter_term(%{__struct__: module}, budget) when is_atom(module),
+  defp consume_parameter_term(%{__struct__: module}, budget, _mode) when is_atom(module),
     do: consume_parameter_node(budget)
 
-  defp consume_parameter_term(map, budget) when is_map(map) do
+  defp consume_parameter_term(map, budget, mode) when is_map(map) do
     with {:ok, budget} <- consume_parameter_node(budget) do
-      Enum.reduce_while(map, {:ok, budget}, &consume_parameter_entry/2)
+      Enum.reduce_while(map, {:ok, budget}, fn entry, acc ->
+        consume_parameter_entry(entry, acc, mode)
+      end)
     end
   end
 
-  defp consume_parameter_term(list, budget) when is_list(list) do
+  defp consume_parameter_term(list, budget, mode) when is_list(list) do
     with {:ok, budget} <- consume_parameter_node(budget) do
       case bounded_charlist_size(list) do
         {:ok, count, size} -> consume_parameter_charlist(count, size, budget)
-        :not_charlist -> consume_parameter_list(list, budget)
+        :not_charlist -> consume_parameter_list(list, budget, mode)
         :error -> :error
       end
     end
   end
 
-  defp consume_parameter_term(value, budget) when is_binary(value) do
+  defp consume_parameter_term(value, budget, _mode) when is_binary(value) do
     with {:ok, budget} <- consume_parameter_node(budget),
          {:ok, budget} <- consume_parameter_value(byte_size(value), budget) do
       consume_parameter_analysis(budget)
     end
   end
 
-  defp consume_parameter_term(value, budget) when is_atom(value) or is_number(value) do
+  defp consume_parameter_term(value, budget, _mode) when is_atom(value) or is_number(value) do
     with {:ok, size} <- bounded_scalar_size(value),
          {:ok, budget} <- consume_parameter_node(budget),
          {:ok, budget} <- consume_parameter_value(size, budget) do
@@ -725,22 +732,23 @@ defmodule Obscura.Internal.PhoenixLog do
     end
   end
 
-  defp consume_parameter_term(_term, budget), do: consume_parameter_node(budget)
+  defp consume_parameter_term(value, _budget, :realtime) when is_tuple(value), do: :error
+  defp consume_parameter_term(_term, budget, _mode), do: consume_parameter_node(budget)
 
-  defp consume_parameter_entry({key, value}, {:ok, budget}) do
+  defp consume_parameter_entry({key, value}, {:ok, budget}, mode) do
     with {:ok, budget} <- consume_parameter_key(key, budget),
-         {:ok, budget} <- consume_parameter_term(value, budget) do
+         {:ok, budget} <- consume_parameter_term(value, budget, mode) do
       {:cont, {:ok, budget}}
     else
       :error -> {:halt, :error}
     end
   end
 
-  defp consume_parameter_list([], budget), do: {:ok, budget}
+  defp consume_parameter_list([], budget, _mode), do: {:ok, budget}
 
-  defp consume_parameter_list([value | rest], budget) do
-    with {:ok, budget} <- consume_parameter_term(value, budget) do
-      if is_list(rest), do: consume_parameter_list(rest, budget), else: {:ok, budget}
+  defp consume_parameter_list([value | rest], budget, mode) do
+    with {:ok, budget} <- consume_parameter_term(value, budget, mode) do
+      if is_list(rest), do: consume_parameter_list(rest, budget, mode), else: {:ok, budget}
     end
   end
 

--- a/lib/obscura/internal/phoenix_log.ex
+++ b/lib/obscura/internal/phoenix_log.ex
@@ -27,6 +27,7 @@ defmodule Obscura.Internal.PhoenixLog do
   @max_measurement 9_223_372_036_854_775_807
 
   @standard_methods ~w(GET HEAD POST PUT PATCH DELETE OPTIONS CONNECT TRACE)
+  @unsafe_static_label ~r/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u
 
   @levels [:debug, :info, :notice, :warning, :error, :critical, :alert, :emergency]
 
@@ -53,6 +54,7 @@ defmodule Obscura.Internal.PhoenixLog do
   @redaction_options [:entities, :max_depth]
 
   @type params_policy :: %{mode: :omit} | map()
+  @type event_labels :: %{optional(String.t()) => String.t()}
   @type correlation_policy ::
           %{mode: :omit}
           | %{mode: :socket_assign, assign: atom(), metadata_key: atom(), format: :uuid}
@@ -265,7 +267,7 @@ defmodule Obscura.Internal.PhoenixLog do
 
   def correlation_metadata(_socket, _policy, true), do: []
 
-  @spec prepare_events(term()) :: {:ok, MapSet.t(String.t())} | {:error, term()}
+  @spec prepare_events(term()) :: {:ok, event_labels()} | {:error, term()}
   def prepare_events(events) when is_list(events) do
     with :ok <- validate_bounded_list(events, @max_events, :events) do
       compile_events(events)
@@ -274,9 +276,12 @@ defmodule Obscura.Internal.PhoenixLog do
 
   def prepare_events(_events), do: invalid_option(:events, :expected_list)
 
-  @spec safe_event(term(), MapSet.t(String.t())) :: String.t()
-  def safe_event(event, allowed) when is_binary(event) do
-    if MapSet.member?(allowed, event), do: event, else: @filtered_event
+  @spec safe_event(term(), event_labels()) :: String.t()
+  def safe_event(event, allowed) when is_binary(event) and is_map(allowed) do
+    case :maps.find(event, allowed) do
+      {:ok, configured_event} -> configured_event
+      :error -> @filtered_event
+    end
   end
 
   def safe_event(_event, _allowed), do: @filtered_event
@@ -442,9 +447,10 @@ defmodule Obscura.Internal.PhoenixLog do
   defp matching_topic_pattern_entry(_topic, _pattern), do: nil
 
   defp compile_events(events) do
-    Enum.reduce_while(events, {:ok, MapSet.new()}, fn event, {:ok, compiled} ->
+    Enum.reduce_while(events, {:ok, %{}}, fn event, {:ok, compiled} ->
       if safe_static_label?(event) do
-        {:cont, {:ok, MapSet.put(compiled, event)}}
+        owned_event = :binary.copy(event)
+        {:cont, {:ok, Map.put(compiled, owned_event, owned_event)}}
       else
         {:halt, invalid_option(:events, :invalid_event)}
       end
@@ -461,7 +467,8 @@ defmodule Obscura.Internal.PhoenixLog do
 
   defp safe_static_label?(label) when is_binary(label) do
     byte_size(label) > 0 and byte_size(label) <= @max_label_bytes and
-      String.valid?(label) and String.printable?(label) and not label_contains_pii?(label)
+      String.valid?(label) and String.printable?(label) and
+      not Regex.match?(@unsafe_static_label, label) and not label_contains_pii?(label)
   end
 
   defp safe_static_label?(_label), do: false
@@ -693,8 +700,9 @@ defmodule Obscura.Internal.PhoenixLog do
   end
 
   defp consume_parameter_term(value, budget) when is_binary(value) do
-    with {:ok, budget} <- consume_parameter_node(budget) do
-      consume_parameter_value(byte_size(value), budget)
+    with {:ok, budget} <- consume_parameter_node(budget),
+         {:ok, budget} <- consume_parameter_value(byte_size(value), budget) do
+      consume_parameter_analysis(budget)
     end
   end
 

--- a/lib/obscura/internal/phoenix_log.ex
+++ b/lib/obscura/internal/phoenix_log.ex
@@ -21,6 +21,7 @@ defmodule Obscura.Internal.PhoenixLog do
   @max_patterns 64
   @max_events 128
   @max_label_bytes 128
+  @max_topic_bytes 4_096
   @max_identifier_bytes 255
   @max_method_bytes 32
   @max_measurement 9_223_372_036_854_775_807
@@ -221,7 +222,8 @@ defmodule Obscura.Internal.PhoenixLog do
     do: invalid_option(:topic_patterns, :expected_list)
 
   @spec safe_topic(term(), list()) :: String.t()
-  def safe_topic(topic, patterns) when is_binary(topic) do
+  def safe_topic(topic, patterns)
+      when is_binary(topic) and byte_size(topic) <= @max_topic_bytes do
     if String.valid?(topic), do: matching_topic_pattern(topic, patterns), else: @filtered_topic
   end
 
@@ -478,7 +480,7 @@ defmodule Obscura.Internal.PhoenixLog do
     text = Atom.to_string(key)
 
     byte_size(text) <= @max_identifier_bytes and identifier_text?(text) and
-      key not in @reserved_logger_metadata_keys
+      key not in @reserved_logger_metadata_keys and not label_contains_pii?(text)
   end
 
   defp uuid?(

--- a/lib/obscura/internal/phoenix_log.ex
+++ b/lib/obscura/internal/phoenix_log.ex
@@ -1,0 +1,765 @@
+defmodule Obscura.Internal.PhoenixLog do
+  @moduledoc false
+
+  require Logger
+
+  @filtered "[FILTERED]"
+  @omitted "[OMITTED]"
+  @filtered_event "[FILTERED EVENT]"
+  @filtered_identifier "[FILTERED IDENTIFIER]"
+  @filtered_topic "[FILTERED TOPIC]"
+  @filtered_key_prefix "[FILTERED KEY "
+
+  @max_parameter_keys 64
+  @max_parameter_key_bytes 4_096
+  @max_parameter_nodes 1_024
+  @max_parameter_value_bytes 65_536
+  @max_parameter_analysis_terms 128
+  @max_numeric_digits 64
+  @max_numeric_magnitude Integer.pow(10, @max_numeric_digits)
+
+  @max_patterns 64
+  @max_events 128
+  @max_label_bytes 128
+  @max_identifier_bytes 255
+  @max_method_bytes 32
+  @max_measurement 9_223_372_036_854_775_807
+
+  @standard_methods ~w(GET HEAD POST PUT PATCH DELETE OPTIONS CONNECT TRACE)
+
+  @levels [:debug, :info, :notice, :warning, :error, :critical, :alert, :emergency]
+
+  @redaction_options [:entities, :max_depth]
+
+  @type params_policy :: %{mode: :omit} | map()
+
+  @spec filtered() :: String.t()
+  def filtered, do: @filtered
+
+  @spec validate_options(term(), [atom()]) :: :ok | {:error, term()}
+  def validate_options(opts, allowed) when is_list(allowed) do
+    cond do
+      not Keyword.keyword?(opts) ->
+        invalid_option(:options, :expected_keyword_list)
+
+      unknown = Keyword.keys(opts) -- allowed ->
+        case unknown do
+          [] -> :ok
+          [option | _rest] -> invalid_option(option, :unknown_option)
+        end
+    end
+  end
+
+  @spec dispatch(pid(), term(), (-> term())) :: :ok
+  def dispatch(owner, handler_id, callback)
+      when is_pid(owner) and is_function(callback, 0) do
+    if Process.alive?(owner) do
+      safely_dispatch(callback)
+    else
+      :telemetry.detach(handler_id)
+      :ok
+    end
+  end
+
+  @spec detach_previous_handlers([[atom()]], module(), term()) :: :ok
+  def detach_previous_handlers(events, module, name) do
+    events
+    |> Enum.flat_map(&:telemetry.list_handlers/1)
+    |> Enum.map(& &1.id)
+    |> Enum.uniq()
+    |> Enum.filter(fn
+      {^module, ^name, _generation} -> true
+      _handler_id -> false
+    end)
+    |> Enum.each(&:telemetry.detach/1)
+  end
+
+  @spec validate_inspect_opts(term()) :: :ok | {:error, term()}
+  def validate_inspect_opts(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      try do
+        _opts = Inspect.Opts.new(opts)
+        _rendered = inspect(%{sample: [1, "value"]}, opts)
+        :ok
+      rescue
+        _error -> {:error, {:invalid_option, :inspect_opts, :invalid_inspect_options}}
+      end
+    else
+      {:error, {:invalid_option, :inspect_opts, :expected_keyword_list}}
+    end
+  end
+
+  def validate_inspect_opts(_opts),
+    do: {:error, {:invalid_option, :inspect_opts, :expected_keyword_list}}
+
+  @spec prepare_params_policy(term(), keyword()) :: {:ok, params_policy()} | {:error, term()}
+  def prepare_params_policy(:omit, _inspect_opts), do: {:ok, %{mode: :omit}}
+
+  def prepare_params_policy({:redact, opts}, inspect_opts) when is_list(opts) do
+    with :ok <- validate_redaction_options(opts),
+         :ok <- validate_fast_profile(opts),
+         {:ok, filter} <- compile_configured_filter(),
+         {:ok, key_entities} <- key_entities(),
+         redaction_opts <-
+           opts
+           |> Keyword.put(:profile, :fast)
+           |> Keyword.put(:telemetry, false)
+           |> Keyword.put(:include_text, false)
+           |> Keyword.put(:traverse_structs, false),
+         {:ok, _probe} <- Obscura.Structured.redact(%{"sample" => "safe"}, redaction_opts) do
+      {:ok,
+       %{
+         mode: :redact,
+         filter: filter,
+         inspect_opts: inspect_opts,
+         key_entities: key_entities,
+         redaction_opts: redaction_opts
+       }}
+    else
+      {:error, {:invalid_option, _, _} = reason} ->
+        {:error, reason}
+
+      {:error, _reason} ->
+        {:error, {:invalid_option, :params, :invalid_redaction_options}}
+    end
+  end
+
+  def prepare_params_policy({:redact, _opts}, _inspect_opts),
+    do: {:error, {:invalid_option, :params, :expected_keyword_list}}
+
+  def prepare_params_policy(_policy, _inspect_opts),
+    do: {:error, {:invalid_option, :params, :expected_omit_or_redact}}
+
+  @spec render_params(term(), params_policy()) :: String.t()
+  def render_params(_params, %{mode: :omit}), do: @omitted
+
+  def render_params(params, %{mode: :redact} = policy) do
+    with true <- parameter_budget_safe?(params),
+         filtered <- apply_parameter_filter(params, policy.filter),
+         {:ok, result} <- Obscura.Structured.redact(filtered, policy.redaction_opts),
+         true <- parameter_budget_safe?(result.data) do
+      result.data
+      |> log_safe_term(policy.key_entities)
+      |> inspect(policy.inspect_opts)
+    else
+      _failure -> @filtered
+    end
+  rescue
+    _error -> @filtered
+  catch
+    _kind, _reason -> @filtered
+  end
+
+  @spec sanitize_params(term(), [atom()] | :filter_all) :: term()
+  def sanitize_params(params, key_entities) do
+    with true <- parameter_budget_safe?(params),
+         {:ok, filter} <- compile_configured_filter() do
+      params
+      |> apply_parameter_filter(filter)
+      |> log_safe_term(key_entities)
+    else
+      _failure -> @filtered
+    end
+  rescue
+    _error -> @filtered
+  catch
+    _kind, _reason -> @filtered
+  end
+
+  @spec key_entities_or_filter_all() :: [atom()] | :filter_all
+  def key_entities_or_filter_all do
+    case key_entities() do
+      {:ok, entities} -> entities
+      {:error, _reason} -> :filter_all
+    end
+  end
+
+  @spec safe_method(term(), [atom()] | :filter_all) :: String.t()
+  def safe_method(method, _key_entities) when method in @standard_methods, do: method
+
+  def safe_method(method, key_entities)
+      when is_binary(method) and byte_size(method) <= @max_method_bytes do
+    if http_token?(method) and
+         not text_contains_pii?(method, value_entities(key_entities)),
+       do: method,
+       else: "[FILTERED METHOD]"
+  end
+
+  def safe_method(_method, _key_entities), do: "[FILTERED METHOD]"
+
+  @spec prepare_topic_patterns(term()) :: {:ok, list()} | {:error, term()}
+  def prepare_topic_patterns(patterns) when is_list(patterns) do
+    with :ok <- validate_bounded_list(patterns, @max_patterns, :topic_patterns) do
+      compile_topic_patterns(patterns)
+    end
+  end
+
+  def prepare_topic_patterns(_patterns),
+    do: invalid_option(:topic_patterns, :expected_list)
+
+  @spec safe_topic(term(), list()) :: String.t()
+  def safe_topic(topic, patterns) when is_binary(topic) do
+    if String.valid?(topic), do: matching_topic_pattern(topic, patterns), else: @filtered_topic
+  end
+
+  def safe_topic(_topic, _patterns), do: @filtered_topic
+
+  @spec prepare_events(term()) :: {:ok, MapSet.t(String.t())} | {:error, term()}
+  def prepare_events(events) when is_list(events) do
+    with :ok <- validate_bounded_list(events, @max_events, :events) do
+      compile_events(events)
+    end
+  end
+
+  def prepare_events(_events), do: invalid_option(:events, :expected_list)
+
+  @spec safe_event(term(), MapSet.t(String.t())) :: String.t()
+  def safe_event(event, allowed) when is_binary(event) do
+    if MapSet.member?(allowed, event), do: event, else: @filtered_event
+  end
+
+  def safe_event(_event, _allowed), do: @filtered_event
+
+  @spec safe_identifier(term()) :: String.t()
+  def safe_identifier(identifier) when is_atom(identifier) and not is_nil(identifier) do
+    text = Atom.to_string(identifier)
+
+    if byte_size(text) <= @max_identifier_bytes and identifier_text?(text) do
+      inspect(identifier)
+    else
+      @filtered_identifier
+    end
+  end
+
+  def safe_identifier(_identifier), do: @filtered_identifier
+
+  @spec safe_result(term()) :: String.t()
+  def safe_result(:ok), do: "ok"
+  def safe_result(:error), do: "error"
+  def safe_result(_result), do: "unknown"
+
+  @spec duration(term()) :: iodata()
+  def duration(value) when is_integer(value) and value >= 0 and value <= @max_measurement do
+    microseconds = System.convert_time_unit(value, :native, :microsecond)
+
+    if microseconds > 1000 do
+      [microseconds |> div(1000) |> Integer.to_string(), "ms"]
+    else
+      [Integer.to_string(microseconds), "us"]
+    end
+  end
+
+  def duration(_value), do: "unknown"
+
+  @spec safe_count(term()) :: String.t()
+  def safe_count(value) when is_integer(value) and value >= 0 and value <= @max_measurement,
+    do: Integer.to_string(value)
+
+  def safe_count(_value), do: "unknown"
+
+  @spec log_level(term(), Logger.level()) :: Logger.level() | false
+  def log_level(false, _default), do: false
+  def log_level(nil, default), do: default
+  def log_level(level, _default) when level in @levels, do: level
+  def log_level(_level, _default), do: false
+
+  @spec log(Logger.level() | false, (-> iodata())) :: :ok
+  def log(false, _message), do: :ok
+
+  def log(level, message) when level in @levels and is_function(message, 0) do
+    metadata = Logger.metadata()
+    Logger.reset_metadata()
+
+    try do
+      Logger.log(level, message)
+    after
+      Logger.reset_metadata(metadata)
+    end
+  end
+
+  def log(_level, _message), do: :ok
+
+  @spec phoenix_logger_attached?([atom()]) :: boolean()
+  def phoenix_logger_attached?(event) do
+    Enum.any?(:telemetry.list_handlers(event), fn
+      %{id: {Phoenix.Logger, ^event}} -> true
+      _handler -> false
+    end)
+  end
+
+  @spec validate_default_logger([[atom()]]) :: :ok | {:error, term()}
+  def validate_default_logger(events) do
+    case Enum.find(events, &phoenix_logger_attached?/1) do
+      nil -> :ok
+      event -> {:error, {:unsafe_phoenix_logger_attached, event}}
+    end
+  end
+
+  defp safely_dispatch(callback) do
+    _result = callback.()
+    :ok
+  rescue
+    _error -> :ok
+  catch
+    _kind, _reason -> :ok
+  end
+
+  defp validate_redaction_options(opts) do
+    cond do
+      not Keyword.keyword?(opts) ->
+        invalid_option(:params, :expected_keyword_list)
+
+      Keyword.has_key?(opts, :profile) and Keyword.get(opts, :profile) != :fast ->
+        invalid_option(:params, :fast_profile_required)
+
+      unsupported = Keyword.keys(opts) -- [:profile | @redaction_options] ->
+        case unsupported do
+          [] -> :ok
+          [option | _rest] -> invalid_option(option, :unsupported_realtime_redaction_option)
+        end
+    end
+  end
+
+  defp validate_fast_profile(opts) do
+    if Keyword.get(opts, :profile, :fast) == :fast,
+      do: :ok,
+      else: invalid_option(:profile, :fast_profile_required)
+  end
+
+  defp compile_topic_pattern(pattern) do
+    if safe_static_label?(pattern) do
+      compile_valid_topic_pattern(pattern, :binary.matches(pattern, "*"))
+    else
+      invalid_option(:topic_patterns, :invalid_pattern)
+    end
+  end
+
+  defp compile_valid_topic_pattern(pattern, []), do: {:ok, {:exact, pattern}}
+
+  defp compile_valid_topic_pattern(pattern, [{index, 1}])
+       when index == byte_size(pattern) - 1 and index > 0 do
+    prefix = binary_part(pattern, 0, index)
+    {:ok, {:prefix, prefix, pattern}}
+  end
+
+  defp compile_valid_topic_pattern("*", [{0, 1}]),
+    do: invalid_option(:topic_patterns, :wildcard_only_pattern)
+
+  defp compile_valid_topic_pattern(_pattern, _matches),
+    do: invalid_option(:topic_patterns, :invalid_pattern)
+
+  defp compile_topic_patterns(patterns) do
+    patterns
+    |> Enum.reduce_while({:ok, []}, &compile_topic_pattern_entry/2)
+    |> reverse_compiled_patterns()
+  end
+
+  defp compile_topic_pattern_entry(pattern, {:ok, compiled}) do
+    case compile_topic_pattern(pattern) do
+      {:ok, entry} -> {:cont, {:ok, [entry | compiled]}}
+      {:error, reason} -> {:halt, {:error, reason}}
+    end
+  end
+
+  defp reverse_compiled_patterns({:ok, compiled}), do: {:ok, Enum.reverse(compiled)}
+  defp reverse_compiled_patterns(error), do: error
+
+  defp matching_topic_pattern(topic, patterns) do
+    Enum.find_value(patterns, @filtered_topic, &matching_topic_pattern_entry(topic, &1))
+  end
+
+  defp matching_topic_pattern_entry(topic, {:exact, pattern}) when topic == pattern, do: pattern
+
+  defp matching_topic_pattern_entry(topic, {:prefix, prefix, pattern}) do
+    if String.starts_with?(topic, prefix), do: pattern
+  end
+
+  defp matching_topic_pattern_entry(_topic, _pattern), do: nil
+
+  defp compile_events(events) do
+    Enum.reduce_while(events, {:ok, MapSet.new()}, fn event, {:ok, compiled} ->
+      if safe_static_label?(event) do
+        {:cont, {:ok, MapSet.put(compiled, event)}}
+      else
+        {:halt, invalid_option(:events, :invalid_event)}
+      end
+    end)
+  end
+
+  defp validate_bounded_list(values, maximum, option) do
+    cond do
+      List.improper?(values) -> invalid_option(option, :expected_proper_list)
+      Enum.count_until(values, maximum + 1) > maximum -> invalid_option(option, :too_many_values)
+      true -> :ok
+    end
+  end
+
+  defp safe_static_label?(label) when is_binary(label) do
+    byte_size(label) > 0 and byte_size(label) <= @max_label_bytes and
+      String.valid?(label) and String.printable?(label) and not label_contains_pii?(label)
+  end
+
+  defp safe_static_label?(_label), do: false
+
+  defp identifier_text?(<<>>), do: false
+  defp identifier_text?(text), do: identifier_bytes?(text)
+  defp identifier_bytes?(<<>>), do: true
+
+  defp identifier_bytes?(<<byte, rest::binary>>)
+       when byte in ?0..?9 or byte in ?A..?Z or byte in ?a..?z or byte in [?_, ?., ?:, ?-],
+       do: identifier_bytes?(rest)
+
+  defp identifier_bytes?(_text), do: false
+
+  defp label_contains_pii?(label) do
+    case key_entities() do
+      {:ok, entities} -> text_contains_pii?(label, [:domain | entities])
+      {:error, _reason} -> true
+    end
+  end
+
+  defp invalid_option(option, reason), do: {:error, {:invalid_option, option, reason}}
+
+  defp compile_configured_filter do
+    :phoenix
+    |> Application.get_env(:filter_parameters, [])
+    |> compile_parameter_filter()
+  end
+
+  defp compile_parameter_filter({:compiled, _key_match, _value_match} = filter),
+    do: {:ok, filter}
+
+  defp compile_parameter_filter({:discard, parameters}),
+    do: compile_parameter_filter(parameters)
+
+  defp compile_parameter_filter({:keep, parameters}) when is_list(parameters),
+    do: {:ok, {:keep, parameters}}
+
+  defp compile_parameter_filter([]), do: {:ok, {:compiled, [], []}}
+
+  defp compile_parameter_filter(parameters)
+       when is_list(parameters) or is_binary(parameters) do
+    parameters = List.wrap(parameters)
+
+    if Enum.all?(parameters, &is_binary/1) do
+      key_match = :binary.compile_pattern(parameters)
+      value_match = parameters |> Enum.map(&(&1 <> "=")) |> :binary.compile_pattern()
+      {:ok, {:compiled, key_match, value_match}}
+    else
+      invalid_option(:filter_parameters, :invalid_phoenix_configuration)
+    end
+  end
+
+  defp compile_parameter_filter(_parameters),
+    do: invalid_option(:filter_parameters, :invalid_phoenix_configuration)
+
+  defp apply_parameter_filter(values, {:compiled, key_match, value_match}),
+    do: discard_parameter_values(values, key_match, value_match)
+
+  defp apply_parameter_filter(values, {:keep, parameters}),
+    do: keep_parameter_values(values, parameters)
+
+  defp discard_parameter_values(%{__struct__: module} = struct, _key_match, _value_match)
+       when is_atom(module),
+       do: struct
+
+  defp discard_parameter_values(map, key_match, value_match) when is_map(map) do
+    Map.new(map, fn {key, value} ->
+      cond do
+        is_binary(key) and String.contains?(key, key_match) ->
+          {key, @filtered}
+
+        is_binary(value) and String.contains?(value, value_match) ->
+          {key, @filtered}
+
+        true ->
+          {key, discard_parameter_values(value, key_match, value_match)}
+      end
+    end)
+  end
+
+  defp discard_parameter_values(list, key_match, value_match) when is_list(list) do
+    if List.improper?(list) do
+      list
+    else
+      Enum.map(list, &discard_parameter_values(&1, key_match, value_match))
+    end
+  end
+
+  defp discard_parameter_values(value, _key_match, _value_match), do: value
+
+  defp keep_parameter_values(%{__struct__: module}, _parameters) when is_atom(module),
+    do: @filtered
+
+  defp keep_parameter_values(map, parameters) when is_map(map) do
+    Map.new(map, fn {key, value} ->
+      if is_binary(key) and key in parameters do
+        {key, value}
+      else
+        {key, keep_parameter_values(value, parameters)}
+      end
+    end)
+  end
+
+  defp keep_parameter_values(list, parameters) when is_list(list) do
+    if List.improper?(list) do
+      @filtered
+    else
+      Enum.map(list, &keep_parameter_values(&1, parameters))
+    end
+  end
+
+  defp keep_parameter_values(_value, _parameters), do: @filtered
+
+  defp log_safe_term(%{__struct__: module}, _key_entities) when is_atom(module), do: @filtered
+
+  defp log_safe_term(map, key_entities) when is_map(map) do
+    map
+    |> Enum.with_index(1)
+    |> Map.new(fn {{key, value}, index} ->
+      {log_safe_key(key, index, key_entities), log_safe_term(value, key_entities)}
+    end)
+  end
+
+  defp log_safe_term(list, key_entities) when is_list(list) do
+    cond do
+      List.improper?(list) -> @filtered
+      flat_charlist?(list) -> log_safe_charlist(list, key_entities)
+      true -> Enum.map(list, &log_safe_term(&1, key_entities))
+    end
+  end
+
+  defp log_safe_term(tuple, _key_entities) when is_tuple(tuple), do: @filtered
+  defp log_safe_term(value, _key_entities) when is_binary(value), do: value
+
+  defp log_safe_term(value, key_entities) when is_number(value) or is_atom(value) do
+    if text_contains_pii?(scalar_text(value), value_entities(key_entities)),
+      do: @filtered,
+      else: value
+  end
+
+  defp log_safe_term(_value, _key_entities), do: @filtered
+
+  defp log_safe_key(key, index, key_entities) when is_binary(key) do
+    if String.starts_with?(key, @filtered_key_prefix) or
+         text_contains_pii?(key, key_entities) do
+      filtered_key(index)
+    else
+      key
+    end
+  end
+
+  defp log_safe_key(key, index, key_entities) when is_atom(key) or is_number(key) do
+    if text_contains_pii?(scalar_text(key), key_entities), do: filtered_key(index), else: key
+  end
+
+  defp log_safe_key(_key, index, _key_entities), do: filtered_key(index)
+
+  defp text_contains_pii?(_text, :filter_all), do: true
+
+  defp text_contains_pii?(text, entities) do
+    case Obscura.redact(text,
+           profile: :fast,
+           entities: entities,
+           include_text: false,
+           telemetry: false
+         ) do
+      {:ok, %{text: ^text}} -> false
+      {:ok, _redacted} -> true
+      {:error, _reason} -> true
+    end
+  end
+
+  defp filtered_key(index), do: @filtered_key_prefix <> Integer.to_string(index) <> "]"
+
+  defp parameter_budget_safe?(params) do
+    match?({:ok, _budget}, consume_parameter_term(params, {0, 0, 0, 0, 0}))
+  end
+
+  defp consume_parameter_term(_term, {nodes, keys, key_bytes, value_bytes, analysis_terms})
+       when nodes >= @max_parameter_nodes or keys > @max_parameter_keys or
+              key_bytes > @max_parameter_key_bytes or
+              value_bytes > @max_parameter_value_bytes or
+              analysis_terms > @max_parameter_analysis_terms,
+       do: :error
+
+  defp consume_parameter_term(%{__struct__: module}, budget) when is_atom(module),
+    do: consume_parameter_node(budget)
+
+  defp consume_parameter_term(map, budget) when is_map(map) do
+    with {:ok, budget} <- consume_parameter_node(budget) do
+      Enum.reduce_while(map, {:ok, budget}, &consume_parameter_entry/2)
+    end
+  end
+
+  defp consume_parameter_term(list, budget) when is_list(list) do
+    with {:ok, budget} <- consume_parameter_node(budget) do
+      case bounded_charlist_size(list) do
+        {:ok, count, size} -> consume_parameter_charlist(count, size, budget)
+        :not_charlist -> consume_parameter_list(list, budget)
+        :error -> :error
+      end
+    end
+  end
+
+  defp consume_parameter_term(value, budget) when is_binary(value) do
+    with {:ok, budget} <- consume_parameter_node(budget) do
+      consume_parameter_value(byte_size(value), budget)
+    end
+  end
+
+  defp consume_parameter_term(value, budget) when is_atom(value) or is_number(value) do
+    with {:ok, size} <- bounded_scalar_size(value),
+         {:ok, budget} <- consume_parameter_node(budget),
+         {:ok, budget} <- consume_parameter_value(size, budget) do
+      consume_parameter_analysis(budget)
+    end
+  end
+
+  defp consume_parameter_term(_term, budget), do: consume_parameter_node(budget)
+
+  defp consume_parameter_entry({key, value}, {:ok, budget}) do
+    with {:ok, budget} <- consume_parameter_key(key, budget),
+         {:ok, budget} <- consume_parameter_term(value, budget) do
+      {:cont, {:ok, budget}}
+    else
+      :error -> {:halt, :error}
+    end
+  end
+
+  defp consume_parameter_list([], budget), do: {:ok, budget}
+
+  defp consume_parameter_list([value | rest], budget) do
+    with {:ok, budget} <- consume_parameter_term(value, budget) do
+      if is_list(rest), do: consume_parameter_list(rest, budget), else: {:ok, budget}
+    end
+  end
+
+  defp consume_parameter_charlist(count, size, budget) do
+    with {:ok, budget} <- consume_parameter_nodes(count, budget),
+         {:ok, budget} <- consume_parameter_value(size, budget) do
+      consume_parameter_analysis(budget)
+    end
+  end
+
+  defp consume_parameter_node({nodes, keys, key_bytes, value_bytes, analysis_terms}) do
+    budget = {nodes + 1, keys, key_bytes, value_bytes, analysis_terms}
+    if elem(budget, 0) > @max_parameter_nodes, do: :error, else: {:ok, budget}
+  end
+
+  defp consume_parameter_nodes(count, {nodes, keys, key_bytes, value_bytes, analysis_terms}) do
+    budget = {nodes + count, keys, key_bytes, value_bytes, analysis_terms}
+    if elem(budget, 0) > @max_parameter_nodes, do: :error, else: {:ok, budget}
+  end
+
+  defp consume_parameter_key(key, {nodes, keys, key_bytes, value_bytes, analysis_terms}) do
+    with {:ok, size} <- bounded_key_size(key) do
+      budget = {nodes, keys + 1, key_bytes + size, value_bytes, analysis_terms}
+
+      if elem(budget, 1) > @max_parameter_keys or
+           elem(budget, 2) > @max_parameter_key_bytes do
+        :error
+      else
+        consume_parameter_key_analysis(key, budget)
+      end
+    end
+  end
+
+  defp consume_parameter_key_analysis(key, budget)
+       when is_binary(key) or is_atom(key) or is_number(key),
+       do: consume_parameter_analysis(budget)
+
+  defp consume_parameter_key_analysis(_key, budget), do: {:ok, budget}
+
+  defp consume_parameter_value(size, {nodes, keys, key_bytes, value_bytes, analysis_terms}) do
+    budget = {nodes, keys, key_bytes, value_bytes + size, analysis_terms}
+    if elem(budget, 3) > @max_parameter_value_bytes, do: :error, else: {:ok, budget}
+  end
+
+  defp consume_parameter_analysis({nodes, keys, key_bytes, value_bytes, analysis_terms}) do
+    budget = {nodes, keys, key_bytes, value_bytes, analysis_terms + 1}
+    if elem(budget, 4) > @max_parameter_analysis_terms, do: :error, else: {:ok, budget}
+  end
+
+  defp bounded_key_size(key) when is_binary(key), do: {:ok, byte_size(key)}
+  defp bounded_key_size(key) when is_atom(key) or is_number(key), do: bounded_scalar_size(key)
+  defp bounded_key_size(_key), do: {:ok, 0}
+
+  defp bounded_scalar_size(value) when is_atom(value),
+    do: {:ok, value |> Atom.to_string() |> byte_size()}
+
+  defp bounded_scalar_size(value) when is_integer(value) do
+    if value > -@max_numeric_magnitude and value < @max_numeric_magnitude,
+      do: {:ok, value |> Integer.to_string() |> byte_size()},
+      else: :error
+  end
+
+  defp bounded_scalar_size(value) when is_float(value),
+    do: {:ok, value |> Float.to_string() |> byte_size()}
+
+  defp bounded_charlist_size([]), do: :not_charlist
+  defp bounded_charlist_size(list), do: bounded_charlist_size(list, 0, 0)
+  defp bounded_charlist_size([], count, size), do: {:ok, count, size}
+
+  defp bounded_charlist_size(_list, count, _size) when count >= @max_parameter_nodes,
+    do: :error
+
+  defp bounded_charlist_size([value | rest], count, size) do
+    if unicode_codepoint?(value) and is_list(rest) do
+      bounded_charlist_size(rest, count + 1, size + utf8_codepoint_size(value))
+    else
+      :not_charlist
+    end
+  end
+
+  defp bounded_charlist_size(_improper, _count, _size), do: :not_charlist
+
+  defp utf8_codepoint_size(value) when value <= 0x7F, do: 1
+  defp utf8_codepoint_size(value) when value <= 0x7FF, do: 2
+  defp utf8_codepoint_size(value) when value <= 0xFFFF, do: 3
+  defp utf8_codepoint_size(_value), do: 4
+
+  defp flat_charlist?([]), do: false
+  defp flat_charlist?(list), do: Enum.all?(list, &unicode_codepoint?/1)
+
+  defp log_safe_charlist(list, key_entities) do
+    if text_contains_pii?(List.to_string(list), value_entities(key_entities)),
+      do: @filtered,
+      else: list
+  end
+
+  defp value_entities(:filter_all), do: :filter_all
+  defp value_entities(key_entities), do: [:domain | key_entities]
+  defp scalar_text(value) when is_atom(value), do: Atom.to_string(value)
+  defp scalar_text(value) when is_number(value), do: to_string(value)
+
+  defp unicode_codepoint?(value) when is_integer(value),
+    do: value >= 0 and value <= 0x10FFFF and value not in 0xD800..0xDFFF
+
+  defp unicode_codepoint?(_value), do: false
+
+  defp http_token?(<<>>), do: false
+  defp http_token?(method), do: http_token_bytes?(method)
+  defp http_token_bytes?(<<>>), do: true
+
+  defp http_token_bytes?(<<byte, rest::binary>>) do
+    if http_token_byte?(byte), do: http_token_bytes?(rest), else: false
+  end
+
+  defp http_token_byte?(byte)
+       when byte in ?0..?9 or byte in ?A..?Z or byte in ?a..?z,
+       do: true
+
+  defp http_token_byte?(byte)
+       when byte in [?!, ?#, ?$, ?%, ?&, ?', ?*, ?+, ?-, ?., ?^, ?_, ?`, ?|, ?~],
+       do: true
+
+  defp http_token_byte?(_byte), do: false
+
+  defp key_entities do
+    case Obscura.Profile.fetch(:fast) do
+      {:ok, profile} -> {:ok, profile.supported_entities -- [:domain]}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/obscura/phoenix/channel_logger.ex
+++ b/lib/obscura/phoenix/channel_logger.ex
@@ -45,9 +45,11 @@ defmodule Obscura.Phoenix.ChannelLogger do
 
   Only the dependency-light `:fast` profile is accepted in this synchronous
   path. Parameter text above the fixed 4 KiB realtime analysis budget is logged
-  as `[FILTERED]` without running PII recognition. Apart from an explicitly
-  configured correlation assign, the handler never inspects socket assigns,
-  private application data, identifiers, references, or callback results.
+  as `[FILTERED]` without running PII recognition. Structs and tuple-bearing
+  terms, including keyword lists, also fail closed without protocol dispatch.
+  Apart from an explicitly configured correlation assign, the handler never
+  inspects socket assigns, private application data, identifiers, references,
+  or callback results.
 
   Configured topic and event labels containing control or directional
   formatting codepoints are rejected. Allowed event labels are emitted from

--- a/lib/obscura/phoenix/channel_logger.ex
+++ b/lib/obscura/phoenix/channel_logger.ex
@@ -34,8 +34,9 @@ defmodule Obscura.Phoenix.ChannelLogger do
        correlation: {:socket_assign, :chat_id, :uuid}}
 
   This metadata supports log correlation; it does not create spans, propagate
-  trace context, or provide distributed tracing. Logger-reserved, PII-bearing,
-  and oversized assign names are rejected at startup.
+  trace context, or provide distributed tracing. Logger-reserved and oversized
+  assign names, plus names containing high-confidence PII recognized by the
+  `:fast` profile, are rejected at startup.
 
   Phoenix's join telemetry contains the socket from before `join/3` runs.
   Consequently, a correlation assign must already exist before `join/3` to
@@ -46,6 +47,10 @@ defmodule Obscura.Phoenix.ChannelLogger do
   path. Apart from an explicitly configured correlation assign, the handler
   never inspects socket assigns, private application data, identifiers,
   references, or callback results.
+
+  Configured topic and event labels containing control or directional
+  formatting codepoints are rejected. Allowed event labels are emitted from
+  owned startup configuration rather than client-frame binaries.
   """
 
   use GenServer

--- a/lib/obscura/phoenix/channel_logger.ex
+++ b/lib/obscura/phoenix/channel_logger.ex
@@ -23,9 +23,22 @@ defmodule Obscura.Phoenix.ChannelLogger do
        join_params: {:redact, entities: [:email, :phone]},
        handle_in_params: {:redact, entities: [:email, :phone]}}
 
+  Applications can opt in to include one validated UUID-valued socket assign
+  as Logger metadata, allowing related channel events to be correlated.
+  Invalid or missing values are omitted:
+
+      {Obscura.Phoenix.ChannelLogger,
+       topic_patterns: ["room:*"],
+       events: ["new_message"],
+       correlation: {:socket_assign, :chat_id, :uuid}}
+
+  This metadata supports log correlation; it does not create spans, propagate
+  trace context, or provide distributed tracing.
+
   Only the dependency-light `:fast` profile is accepted in this synchronous
-  path. The handler never inspects socket assigns, private application data,
-  identifiers, references, or callback results.
+  path. Apart from an explicitly configured correlation assign, the handler
+  never inspects socket assigns, private application data, identifiers,
+  references, or callback results.
   """
 
   use GenServer
@@ -35,6 +48,7 @@ defmodule Obscura.Phoenix.ChannelLogger do
   @events [[:phoenix, :channel_joined], [:phoenix, :channel_handled_in]]
 
   @allowed_options [
+    :correlation,
     :events,
     :handle_in_params,
     :inspect_opts,
@@ -61,6 +75,8 @@ defmodule Obscura.Phoenix.ChannelLogger do
          {:ok, topic_patterns} <-
            PhoenixLog.prepare_topic_patterns(Keyword.get(opts, :topic_patterns, [])),
          {:ok, events} <- PhoenixLog.prepare_events(Keyword.get(opts, :events, [])),
+         {:ok, correlation} <-
+           PhoenixLog.prepare_correlation(Keyword.get(opts, :correlation, :omit)),
          {:ok, join_params} <-
            PhoenixLog.prepare_params_policy(Keyword.get(opts, :join_params, :omit), inspect_opts),
          {:ok, handle_in_params} <-
@@ -73,6 +89,7 @@ defmodule Obscura.Phoenix.ChannelLogger do
       detach_previous_handlers(name)
 
       config = %{
+        correlation: correlation,
         events: events,
         handle_in_params: handle_in_params,
         handler_id: handler_id,
@@ -116,18 +133,29 @@ defmodule Obscura.Phoenix.ChannelLogger do
     else
       level = channel_level(socket, :log_join)
 
-      PhoenixLog.log(level, fn ->
-        [
-          join_result(Map.get(metadata, :result)),
-          PhoenixLog.safe_topic(Map.get(socket, :topic), config.topic_patterns),
-          " (",
-          PhoenixLog.safe_identifier(Map.get(socket, :channel)),
-          ") in ",
-          PhoenixLog.duration(Map.get(measurements, :duration)),
-          "\n  Parameters: ",
-          PhoenixLog.render_params(Map.get(metadata, :params), config.join_params)
-        ]
-      end)
+      correlation_metadata =
+        PhoenixLog.correlation_metadata(
+          socket,
+          config.correlation,
+          Map.get(metadata, :result) == :ok
+        )
+
+      PhoenixLog.log(
+        level,
+        fn ->
+          [
+            join_result(Map.get(metadata, :result)),
+            PhoenixLog.safe_topic(Map.get(socket, :topic), config.topic_patterns),
+            " (",
+            PhoenixLog.safe_identifier(Map.get(socket, :channel)),
+            ") in ",
+            PhoenixLog.duration(Map.get(measurements, :duration)),
+            "\n  Parameters: ",
+            PhoenixLog.render_params(Map.get(metadata, :params), config.join_params)
+          ]
+        end,
+        correlation_metadata
+      )
     end
   end
 
@@ -138,21 +166,26 @@ defmodule Obscura.Phoenix.ChannelLogger do
       :ok
     else
       level = channel_level(socket, :log_handle_in)
+      correlation_metadata = PhoenixLog.correlation_metadata(socket, config.correlation, true)
 
-      PhoenixLog.log(level, fn ->
-        [
-          "HANDLED ",
-          PhoenixLog.safe_event(Map.get(metadata, :event), config.events),
-          " ON ",
-          PhoenixLog.safe_topic(Map.get(socket, :topic), config.topic_patterns),
-          " (",
-          PhoenixLog.safe_identifier(Map.get(socket, :channel)),
-          ") in ",
-          PhoenixLog.duration(Map.get(measurements, :duration)),
-          "\n  Parameters: ",
-          PhoenixLog.render_params(Map.get(metadata, :params), config.handle_in_params)
-        ]
-      end)
+      PhoenixLog.log(
+        level,
+        fn ->
+          [
+            "HANDLED ",
+            PhoenixLog.safe_event(Map.get(metadata, :event), config.events),
+            " ON ",
+            PhoenixLog.safe_topic(Map.get(socket, :topic), config.topic_patterns),
+            " (",
+            PhoenixLog.safe_identifier(Map.get(socket, :channel)),
+            ") in ",
+            PhoenixLog.duration(Map.get(measurements, :duration)),
+            "\n  Parameters: ",
+            PhoenixLog.render_params(Map.get(metadata, :params), config.handle_in_params)
+          ]
+        end,
+        correlation_metadata
+      )
     end
   end
 

--- a/lib/obscura/phoenix/channel_logger.ex
+++ b/lib/obscura/phoenix/channel_logger.ex
@@ -1,0 +1,180 @@
+defmodule Obscura.Phoenix.ChannelLogger do
+  @moduledoc """
+  Privacy-safe logging for Phoenix channel joins and incoming events.
+
+  This opt-in telemetry handler replaces the channel portion of Phoenix's
+  default logger after `config :phoenix, :logger, false` disables it. Raw topics
+  and event names are never logged. Applications declare safe topic patterns
+  and event names at startup; unmatched values are rendered as filtered labels.
+  Join and incoming-event parameters are omitted by default.
+
+      children = [
+        {Obscura.Phoenix.ChannelLogger,
+         topic_patterns: ["room:*", "system"],
+         events: ["new_message", "typing"]}
+      ]
+
+  A bounded redacted parameter copy can be enabled independently for joins and
+  incoming events:
+
+      {Obscura.Phoenix.ChannelLogger,
+       topic_patterns: ["room:*"],
+       events: ["new_message"],
+       join_params: {:redact, entities: [:email, :phone]},
+       handle_in_params: {:redact, entities: [:email, :phone]}}
+
+  Only the dependency-light `:fast` profile is accepted in this synchronous
+  path. The handler never inspects socket assigns, private application data,
+  identifiers, references, or callback results.
+  """
+
+  use GenServer
+
+  alias Obscura.Internal.PhoenixLog
+
+  @events [[:phoenix, :channel_joined], [:phoenix, :channel_handled_in]]
+
+  @allowed_options [
+    :events,
+    :handle_in_params,
+    :inspect_opts,
+    :join_params,
+    :name,
+    :topic_patterns
+  ]
+
+  @doc "Starts the Phoenix channel telemetry handler."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    with :ok <- PhoenixLog.validate_options(opts, @allowed_options),
+         :ok <- PhoenixLog.validate_default_logger(@events),
+         inspect_opts = Keyword.get(opts, :inspect_opts, limit: 50, printable_limit: 500),
+         :ok <- PhoenixLog.validate_inspect_opts(inspect_opts),
+         {:ok, topic_patterns} <-
+           PhoenixLog.prepare_topic_patterns(Keyword.get(opts, :topic_patterns, [])),
+         {:ok, events} <- PhoenixLog.prepare_events(Keyword.get(opts, :events, [])),
+         {:ok, join_params} <-
+           PhoenixLog.prepare_params_policy(Keyword.get(opts, :join_params, :omit), inspect_opts),
+         {:ok, handle_in_params} <-
+           PhoenixLog.prepare_params_policy(
+             Keyword.get(opts, :handle_in_params, :omit),
+             inspect_opts
+           ) do
+      name = Keyword.get(opts, :name, __MODULE__)
+      handler_id = {__MODULE__, name, make_ref()}
+      detach_previous_handlers(name)
+
+      config = %{
+        events: events,
+        handle_in_params: handle_in_params,
+        handler_id: handler_id,
+        join_params: join_params,
+        owner: self(),
+        topic_patterns: topic_patterns
+      }
+
+      case :telemetry.attach_many(handler_id, @events, &__MODULE__.handle_event/4, config) do
+        :ok -> {:ok, handler_id}
+        {:error, reason} -> {:stop, reason}
+      end
+    else
+      {:error, reason} -> {:stop, reason}
+    end
+  end
+
+  @impl true
+  def terminate(_reason, handler_id) do
+    :telemetry.detach(handler_id)
+  end
+
+  @doc false
+  @spec handle_event([atom()], map(), map(), map()) :: :ok
+  def handle_event(
+        event,
+        measurements,
+        metadata,
+        %{owner: owner, handler_id: handler_id} = config
+      ) do
+    PhoenixLog.dispatch(owner, handler_id, fn ->
+      dispatch(event, measurements, metadata, config)
+    end)
+  end
+
+  defp dispatch([:phoenix, :channel_joined], measurements, metadata, config) do
+    socket = Map.get(metadata, :socket, %{})
+
+    if internal_topic?(Map.get(socket, :topic)) do
+      :ok
+    else
+      level = channel_level(socket, :log_join)
+
+      PhoenixLog.log(level, fn ->
+        [
+          join_result(Map.get(metadata, :result)),
+          PhoenixLog.safe_topic(Map.get(socket, :topic), config.topic_patterns),
+          " (",
+          PhoenixLog.safe_identifier(Map.get(socket, :channel)),
+          ") in ",
+          PhoenixLog.duration(Map.get(measurements, :duration)),
+          "\n  Parameters: ",
+          PhoenixLog.render_params(Map.get(metadata, :params), config.join_params)
+        ]
+      end)
+    end
+  end
+
+  defp dispatch([:phoenix, :channel_handled_in], measurements, metadata, config) do
+    socket = Map.get(metadata, :socket, %{})
+
+    if internal_topic?(Map.get(socket, :topic)) do
+      :ok
+    else
+      level = channel_level(socket, :log_handle_in)
+
+      PhoenixLog.log(level, fn ->
+        [
+          "HANDLED ",
+          PhoenixLog.safe_event(Map.get(metadata, :event), config.events),
+          " ON ",
+          PhoenixLog.safe_topic(Map.get(socket, :topic), config.topic_patterns),
+          " (",
+          PhoenixLog.safe_identifier(Map.get(socket, :channel)),
+          ") in ",
+          PhoenixLog.duration(Map.get(measurements, :duration)),
+          "\n  Parameters: ",
+          PhoenixLog.render_params(Map.get(metadata, :params), config.handle_in_params)
+        ]
+      end)
+    end
+  end
+
+  defp dispatch(_event, _measurements, _metadata, _config), do: :ok
+
+  defp channel_level(%{private: private}, key) when is_map(private) do
+    case Map.get(private, key) do
+      nil -> false
+      level -> PhoenixLog.log_level(level, :info)
+    end
+  end
+
+  defp channel_level(_socket, _key), do: false
+
+  defp internal_topic?("phoenix" <> _rest), do: true
+  defp internal_topic?(_topic), do: false
+
+  defp join_result(:ok), do: "JOINED "
+  defp join_result(:error), do: "REFUSED JOIN "
+  defp join_result(_result), do: "CHANNEL JOIN "
+
+  defp detach_previous_handlers(name) do
+    PhoenixLog.detach_previous_handlers(@events, __MODULE__, name)
+  end
+end

--- a/lib/obscura/phoenix/channel_logger.ex
+++ b/lib/obscura/phoenix/channel_logger.ex
@@ -33,7 +33,13 @@ defmodule Obscura.Phoenix.ChannelLogger do
        correlation: {:socket_assign, :chat_id, :uuid}}
 
   This metadata supports log correlation; it does not create spans, propagate
-  trace context, or provide distributed tracing.
+  trace context, or provide distributed tracing. Logger-reserved and oversized
+  assign names are rejected at startup.
+
+  Phoenix's join telemetry contains the socket from before `join/3` runs.
+  Consequently, a correlation assign must already exist before `join/3` to
+  appear on the join record. An assign added by `join/3` is available to later
+  handled-event records.
 
   Only the dependency-light `:fast` profile is accepted in this synchronous
   path. Apart from an explicitly configured correlation assign, the handler
@@ -131,31 +137,35 @@ defmodule Obscura.Phoenix.ChannelLogger do
     if internal_topic?(Map.get(socket, :topic)) do
       :ok
     else
-      level = channel_level(socket, :log_join)
+      case channel_level(socket, :log_join) do
+        false ->
+          :ok
 
-      correlation_metadata =
-        PhoenixLog.correlation_metadata(
-          socket,
-          config.correlation,
-          Map.get(metadata, :result) == :ok
-        )
+        level ->
+          correlation_metadata =
+            PhoenixLog.correlation_metadata(
+              socket,
+              config.correlation,
+              Map.get(metadata, :result) == :ok
+            )
 
-      PhoenixLog.log(
-        level,
-        fn ->
-          [
-            join_result(Map.get(metadata, :result)),
-            PhoenixLog.safe_topic(Map.get(socket, :topic), config.topic_patterns),
-            " (",
-            PhoenixLog.safe_identifier(Map.get(socket, :channel)),
-            ") in ",
-            PhoenixLog.duration(Map.get(measurements, :duration)),
-            "\n  Parameters: ",
-            PhoenixLog.render_params(Map.get(metadata, :params), config.join_params)
-          ]
-        end,
-        correlation_metadata
-      )
+          PhoenixLog.log(
+            level,
+            fn ->
+              [
+                join_result(Map.get(metadata, :result)),
+                PhoenixLog.safe_topic(Map.get(socket, :topic), config.topic_patterns),
+                " (",
+                PhoenixLog.safe_identifier(Map.get(socket, :channel)),
+                ") in ",
+                PhoenixLog.duration(Map.get(measurements, :duration)),
+                "\n  Parameters: ",
+                PhoenixLog.render_params(Map.get(metadata, :params), config.join_params)
+              ]
+            end,
+            correlation_metadata
+          )
+      end
     end
   end
 
@@ -165,27 +175,32 @@ defmodule Obscura.Phoenix.ChannelLogger do
     if internal_topic?(Map.get(socket, :topic)) do
       :ok
     else
-      level = channel_level(socket, :log_handle_in)
-      correlation_metadata = PhoenixLog.correlation_metadata(socket, config.correlation, true)
+      case channel_level(socket, :log_handle_in) do
+        false ->
+          :ok
 
-      PhoenixLog.log(
-        level,
-        fn ->
-          [
-            "HANDLED ",
-            PhoenixLog.safe_event(Map.get(metadata, :event), config.events),
-            " ON ",
-            PhoenixLog.safe_topic(Map.get(socket, :topic), config.topic_patterns),
-            " (",
-            PhoenixLog.safe_identifier(Map.get(socket, :channel)),
-            ") in ",
-            PhoenixLog.duration(Map.get(measurements, :duration)),
-            "\n  Parameters: ",
-            PhoenixLog.render_params(Map.get(metadata, :params), config.handle_in_params)
-          ]
-        end,
-        correlation_metadata
-      )
+        level ->
+          correlation_metadata = PhoenixLog.correlation_metadata(socket, config.correlation, true)
+
+          PhoenixLog.log(
+            level,
+            fn ->
+              [
+                "HANDLED ",
+                PhoenixLog.safe_event(Map.get(metadata, :event), config.events),
+                " ON ",
+                PhoenixLog.safe_topic(Map.get(socket, :topic), config.topic_patterns),
+                " (",
+                PhoenixLog.safe_identifier(Map.get(socket, :channel)),
+                ") in ",
+                PhoenixLog.duration(Map.get(measurements, :duration)),
+                "\n  Parameters: ",
+                PhoenixLog.render_params(Map.get(metadata, :params), config.handle_in_params)
+              ]
+            end,
+            correlation_metadata
+          )
+      end
     end
   end
 

--- a/lib/obscura/phoenix/channel_logger.ex
+++ b/lib/obscura/phoenix/channel_logger.ex
@@ -44,9 +44,10 @@ defmodule Obscura.Phoenix.ChannelLogger do
   handled-event records.
 
   Only the dependency-light `:fast` profile is accepted in this synchronous
-  path. Apart from an explicitly configured correlation assign, the handler
-  never inspects socket assigns, private application data, identifiers,
-  references, or callback results.
+  path. Parameter text above the fixed 4 KiB realtime analysis budget is logged
+  as `[FILTERED]` without running PII recognition. Apart from an explicitly
+  configured correlation assign, the handler never inspects socket assigns,
+  private application data, identifiers, references, or callback results.
 
   Configured topic and event labels containing control or directional
   formatting codepoints are rejected. Allowed event labels are emitted from

--- a/lib/obscura/phoenix/channel_logger.ex
+++ b/lib/obscura/phoenix/channel_logger.ex
@@ -6,7 +6,8 @@ defmodule Obscura.Phoenix.ChannelLogger do
   default logger after `config :phoenix, :logger, false` disables it. Raw topics
   and event names are never logged. Applications declare safe topic patterns
   and event names at startup; unmatched values are rendered as filtered labels.
-  Join and incoming-event parameters are omitted by default.
+  Oversized topics are filtered before content validation. Join and
+  incoming-event parameters are omitted by default.
 
       children = [
         {Obscura.Phoenix.ChannelLogger,
@@ -33,8 +34,8 @@ defmodule Obscura.Phoenix.ChannelLogger do
        correlation: {:socket_assign, :chat_id, :uuid}}
 
   This metadata supports log correlation; it does not create spans, propagate
-  trace context, or provide distributed tracing. Logger-reserved and oversized
-  assign names are rejected at startup.
+  trace context, or provide distributed tracing. Logger-reserved, PII-bearing,
+  and oversized assign names are rejected at startup.
 
   Phoenix's join telemetry contains the socket from before `join/3` runs.
   Consequently, a correlation assign must already exist before `join/3` to

--- a/lib/obscura/phoenix/logger.ex
+++ b/lib/obscura/phoenix/logger.ex
@@ -36,6 +36,7 @@ defmodule Obscura.Phoenix.Logger do
 
   require Elixir.Logger
 
+  alias Obscura.Internal.PhoenixLog
   alias Plug.Conn.Status, as: ConnStatus
 
   @events [
@@ -45,18 +46,6 @@ defmodule Obscura.Phoenix.Logger do
   ]
 
   @filtered "[FILTERED]"
-  @filtered_key_prefix "[FILTERED KEY "
-
-  @max_parameter_keys 64
-  @max_parameter_key_bytes 4_096
-  @max_parameter_nodes 1_024
-  @max_parameter_value_bytes 65_536
-  @max_parameter_analysis_terms 128
-  @max_numeric_digits 64
-  @max_numeric_magnitude Integer.pow(10, @max_numeric_digits)
-
-  @max_method_bytes 32
-  @standard_methods ~w(GET HEAD POST PUT PATCH DELETE OPTIONS CONNECT TRACE)
 
   @allowed_options [:assign, :inspect_opts, :name]
 
@@ -157,7 +146,7 @@ defmodule Obscura.Phoenix.Logger do
 
       [
         "Processing ",
-        safe_method(conn.method, Map.fetch!(config, :key_entities)),
+        PhoenixLog.safe_method(conn.method, Map.fetch!(config, :key_entities)),
         " with ",
         route(metadata),
         ?\n,
@@ -227,119 +216,15 @@ defmodule Obscura.Phoenix.Logger do
   end
 
   defp safe_parameters(conn, config) do
-    params = redacted_params(conn, config)
-
-    if parameter_budget_safe?(params) do
-      params
-      |> filter_parameters()
-      |> log_safe_term(Map.fetch!(config, :key_entities))
-    else
-      @filtered
-    end
-  rescue
-    _error -> @filtered
-  catch
-    _kind, _reason -> @filtered
+    conn
+    |> redacted_params(config)
+    |> PhoenixLog.sanitize_params(Map.fetch!(config, :key_entities))
   end
-
-  defp filter_parameters(values) do
-    :phoenix
-    |> Application.get_env(:filter_parameters, [])
-    |> compile_parameter_filter()
-    |> case do
-      {:ok, filter} -> apply_parameter_filter(values, filter)
-      :error -> @filtered
-    end
-  end
-
-  defp compile_parameter_filter({:compiled, _key_match, _value_match} = filter),
-    do: {:ok, filter}
-
-  defp compile_parameter_filter({:discard, parameters}),
-    do: compile_parameter_filter(parameters)
-
-  defp compile_parameter_filter({:keep, parameters}) when is_list(parameters),
-    do: {:ok, {:keep, parameters}}
-
-  defp compile_parameter_filter([]), do: {:ok, {:compiled, [], []}}
-
-  defp compile_parameter_filter(parameters)
-       when is_list(parameters) or is_binary(parameters) do
-    parameters = List.wrap(parameters)
-
-    if Enum.all?(parameters, &is_binary/1) do
-      key_match = :binary.compile_pattern(parameters)
-      value_match = parameters |> Enum.map(&(&1 <> "=")) |> :binary.compile_pattern()
-      {:ok, {:compiled, key_match, value_match}}
-    else
-      :error
-    end
-  end
-
-  defp compile_parameter_filter(_parameters), do: :error
-
-  defp apply_parameter_filter(values, {:compiled, key_match, value_match}),
-    do: discard_parameter_values(values, key_match, value_match)
-
-  defp apply_parameter_filter(values, {:keep, parameters}),
-    do: keep_parameter_values(values, parameters)
-
-  defp discard_parameter_values(%{__struct__: module} = struct, _key_match, _value_match)
-       when is_atom(module),
-       do: struct
-
-  defp discard_parameter_values(map, key_match, value_match) when is_map(map) do
-    Map.new(map, fn {key, value} ->
-      cond do
-        is_binary(key) and String.contains?(key, key_match) ->
-          {key, @filtered}
-
-        is_binary(value) and String.contains?(value, value_match) ->
-          {key, @filtered}
-
-        true ->
-          {key, discard_parameter_values(value, key_match, value_match)}
-      end
-    end)
-  end
-
-  defp discard_parameter_values(list, key_match, value_match) when is_list(list) do
-    if List.improper?(list) do
-      list
-    else
-      Enum.map(list, &discard_parameter_values(&1, key_match, value_match))
-    end
-  end
-
-  defp discard_parameter_values(value, _key_match, _value_match), do: value
-
-  defp keep_parameter_values(%{__struct__: module}, _parameters) when is_atom(module),
-    do: @filtered
-
-  defp keep_parameter_values(map, parameters) when is_map(map) do
-    Map.new(map, fn {key, value} ->
-      if is_binary(key) and key in parameters do
-        {key, value}
-      else
-        {key, keep_parameter_values(value, parameters)}
-      end
-    end)
-  end
-
-  defp keep_parameter_values(list, parameters) when is_list(list) do
-    if List.improper?(list) do
-      @filtered
-    else
-      Enum.map(list, &keep_parameter_values(&1, parameters))
-    end
-  end
-
-  defp keep_parameter_values(_value, _parameters), do: @filtered
 
   defp handler_config(opts) do
-    with :ok <- validate_options(opts),
+    with :ok <- PhoenixLog.validate_options(opts, @allowed_options),
          :ok <- validate_assign(Keyword.get(opts, :assign, :obscura_redacted)),
-         :ok <- validate_inspect_opts(Keyword.get(opts, :inspect_opts, [])) do
+         :ok <- PhoenixLog.validate_inspect_opts(Keyword.get(opts, :inspect_opts, [])) do
       name = Keyword.get(opts, :name, __MODULE__)
       handler_id = {__MODULE__, name, make_ref()}
 
@@ -349,7 +234,7 @@ defmodule Obscura.Phoenix.Logger do
         |> Map.new()
         |> Map.merge(%{
           handler_id: handler_id,
-          key_entities: key_entities(),
+          key_entities: PhoenixLog.key_entities_or_filter_all(),
           owner: self()
         })
 
@@ -359,346 +244,12 @@ defmodule Obscura.Phoenix.Logger do
     end
   end
 
-  defp validate_options(opts) do
-    case Keyword.keys(opts) -- @allowed_options do
-      [] -> :ok
-      [option | _rest] -> {:error, {:invalid_option, option, :unknown_option}}
-    end
-  end
-
   defp validate_assign(assign) when is_atom(assign), do: :ok
   defp validate_assign(_assign), do: {:error, {:invalid_option, :assign, :expected_atom}}
 
-  defp validate_inspect_opts(opts) when is_list(opts) do
-    if Keyword.keyword?(opts) do
-      try do
-        _opts = Inspect.Opts.new(opts)
-        _rendered = inspect(%{sample: [1, "value"]}, opts)
-        :ok
-      rescue
-        _error -> {:error, {:invalid_option, :inspect_opts, :invalid_inspect_options}}
-      end
-    else
-      {:error, {:invalid_option, :inspect_opts, :expected_keyword_list}}
-    end
-  end
-
-  defp validate_inspect_opts(_opts),
-    do: {:error, {:invalid_option, :inspect_opts, :expected_keyword_list}}
-
   defp detach_previous_handlers(name) do
-    @events
-    |> Enum.flat_map(&:telemetry.list_handlers/1)
-    |> Enum.map(& &1.id)
-    |> Enum.uniq()
-    |> Enum.filter(fn
-      {__MODULE__, ^name, _generation} -> true
-      _handler_id -> false
-    end)
-    |> Enum.each(&:telemetry.detach/1)
+    PhoenixLog.detach_previous_handlers(@events, __MODULE__, name)
   end
-
-  defp log_safe_term(%{__struct__: module}, _key_entities) when is_atom(module), do: @filtered
-
-  defp log_safe_term(map, key_entities) when is_map(map) do
-    map
-    |> Enum.with_index(1)
-    |> Map.new(fn {{key, value}, index} ->
-      {log_safe_key(key, index, key_entities), log_safe_term(value, key_entities)}
-    end)
-  end
-
-  defp log_safe_term(list, key_entities) when is_list(list) do
-    cond do
-      List.improper?(list) -> @filtered
-      flat_charlist?(list) -> log_safe_charlist(list, key_entities)
-      true -> Enum.map(list, &log_safe_term(&1, key_entities))
-    end
-  end
-
-  defp log_safe_term(tuple, _key_entities) when is_tuple(tuple), do: @filtered
-
-  defp log_safe_term(value, _key_entities) when is_binary(value), do: value
-
-  defp log_safe_term(value, key_entities) when is_number(value) or is_atom(value) do
-    if text_contains_pii?(scalar_text(value), value_entities(key_entities)) do
-      @filtered
-    else
-      value
-    end
-  end
-
-  defp log_safe_term(_value, _key_entities), do: @filtered
-
-  defp log_safe_key(key, index, key_entities) when is_binary(key) do
-    if String.starts_with?(key, @filtered_key_prefix) or
-         text_contains_pii?(key, key_entities) do
-      filtered_key(index)
-    else
-      key
-    end
-  end
-
-  defp log_safe_key(key, index, key_entities) when is_atom(key) or is_number(key) do
-    if text_contains_pii?(scalar_text(key), key_entities), do: filtered_key(index), else: key
-  end
-
-  defp log_safe_key(_key, index, _key_entities), do: filtered_key(index)
-
-  defp text_contains_pii?(_text, :filter_all), do: true
-
-  defp text_contains_pii?(text, entities) when is_list(entities) do
-    case Obscura.redact(text,
-           profile: :fast,
-           entities: entities,
-           include_text: false,
-           telemetry: false
-         ) do
-      {:ok, %{text: ^text}} -> false
-      {:ok, _redacted} -> true
-      {:error, _reason} -> true
-    end
-  end
-
-  defp filtered_key(index), do: @filtered_key_prefix <> Integer.to_string(index) <> "]"
-
-  defp parameter_budget_safe?(params) do
-    match?({:ok, _budget}, consume_parameter_term(params, {0, 0, 0, 0, 0}))
-  end
-
-  defp consume_parameter_term(_term, {nodes, keys, key_bytes, value_bytes, analysis_terms})
-       when nodes >= @max_parameter_nodes or keys > @max_parameter_keys or
-              key_bytes > @max_parameter_key_bytes or
-              value_bytes > @max_parameter_value_bytes or
-              analysis_terms > @max_parameter_analysis_terms,
-       do: :error
-
-  defp consume_parameter_term(%{__struct__: module}, budget) when is_atom(module),
-    do: consume_parameter_node(budget)
-
-  defp consume_parameter_term(map, budget) when is_map(map) do
-    with {:ok, budget} <- consume_parameter_node(budget) do
-      Enum.reduce_while(map, {:ok, budget}, &consume_parameter_entry/2)
-    end
-  end
-
-  defp consume_parameter_term(list, budget) when is_list(list) do
-    with {:ok, budget} <- consume_parameter_node(budget) do
-      case bounded_charlist_size(list) do
-        {:ok, count, size} ->
-          consume_parameter_charlist(count, size, budget)
-
-        :not_charlist ->
-          consume_parameter_list(list, budget)
-
-        :error ->
-          :error
-      end
-    end
-  end
-
-  defp consume_parameter_term(value, budget) when is_binary(value) do
-    with {:ok, budget} <- consume_parameter_node(budget) do
-      consume_parameter_value(byte_size(value), budget)
-    end
-  end
-
-  defp consume_parameter_term(value, budget) when is_atom(value) or is_number(value) do
-    with {:ok, size} <- bounded_scalar_size(value),
-         {:ok, budget} <- consume_parameter_node(budget),
-         {:ok, budget} <- consume_parameter_value(size, budget) do
-      consume_parameter_analysis(budget)
-    end
-  end
-
-  defp consume_parameter_term(_term, budget), do: consume_parameter_node(budget)
-
-  defp consume_parameter_entry({key, value}, {:ok, budget}) do
-    with {:ok, budget} <- consume_parameter_key(key, budget),
-         {:ok, budget} <- consume_parameter_term(value, budget) do
-      {:cont, {:ok, budget}}
-    else
-      :error -> {:halt, :error}
-    end
-  end
-
-  defp consume_parameter_list([], budget), do: {:ok, budget}
-
-  defp consume_parameter_list([value | rest], budget) do
-    with {:ok, budget} <- consume_parameter_term(value, budget) do
-      if is_list(rest), do: consume_parameter_list(rest, budget), else: {:ok, budget}
-    end
-  end
-
-  defp consume_parameter_charlist(count, size, budget) do
-    with {:ok, budget} <- consume_parameter_nodes(count, budget),
-         {:ok, budget} <- consume_parameter_value(size, budget) do
-      consume_parameter_analysis(budget)
-    end
-  end
-
-  defp consume_parameter_node({nodes, keys, key_bytes, value_bytes, analysis_terms}) do
-    budget = {nodes + 1, keys, key_bytes, value_bytes, analysis_terms}
-
-    if elem(budget, 0) > @max_parameter_nodes, do: :error, else: {:ok, budget}
-  end
-
-  defp consume_parameter_nodes(
-         count,
-         {nodes, keys, key_bytes, value_bytes, analysis_terms}
-       ) do
-    budget = {nodes + count, keys, key_bytes, value_bytes, analysis_terms}
-
-    if elem(budget, 0) > @max_parameter_nodes, do: :error, else: {:ok, budget}
-  end
-
-  defp consume_parameter_key(key, {nodes, keys, key_bytes, value_bytes, analysis_terms}) do
-    with {:ok, size} <- bounded_key_size(key) do
-      budget = {nodes, keys + 1, key_bytes + size, value_bytes, analysis_terms}
-
-      if elem(budget, 1) > @max_parameter_keys or
-           elem(budget, 2) > @max_parameter_key_bytes do
-        :error
-      else
-        consume_parameter_key_analysis(key, budget)
-      end
-    end
-  end
-
-  defp consume_parameter_key_analysis(key, budget)
-       when is_binary(key) or is_atom(key) or is_number(key),
-       do: consume_parameter_analysis(budget)
-
-  defp consume_parameter_key_analysis(_key, budget), do: {:ok, budget}
-
-  defp consume_parameter_value(
-         size,
-         {nodes, keys, key_bytes, value_bytes, analysis_terms}
-       ) do
-    budget = {nodes, keys, key_bytes, value_bytes + size, analysis_terms}
-
-    if elem(budget, 3) > @max_parameter_value_bytes, do: :error, else: {:ok, budget}
-  end
-
-  defp consume_parameter_analysis({nodes, keys, key_bytes, value_bytes, analysis_terms}) do
-    budget = {nodes, keys, key_bytes, value_bytes, analysis_terms + 1}
-
-    if elem(budget, 4) > @max_parameter_analysis_terms do
-      :error
-    else
-      {:ok, budget}
-    end
-  end
-
-  defp bounded_key_size(key) when is_binary(key), do: {:ok, byte_size(key)}
-
-  defp bounded_key_size(key) when is_atom(key) or is_number(key),
-    do: bounded_scalar_size(key)
-
-  defp bounded_key_size(_key), do: {:ok, 0}
-
-  defp bounded_scalar_size(value) when is_atom(value),
-    do: {:ok, value |> Atom.to_string() |> byte_size()}
-
-  defp bounded_scalar_size(value) when is_integer(value) do
-    if value > -@max_numeric_magnitude and value < @max_numeric_magnitude do
-      {:ok, value |> Integer.to_string() |> byte_size()}
-    else
-      :error
-    end
-  end
-
-  defp bounded_scalar_size(value) when is_float(value),
-    do: {:ok, value |> Float.to_string() |> byte_size()}
-
-  defp bounded_charlist_size([]), do: :not_charlist
-  defp bounded_charlist_size(list), do: bounded_charlist_size(list, 0, 0)
-
-  defp bounded_charlist_size([], count, size), do: {:ok, count, size}
-
-  defp bounded_charlist_size(_list, count, _size) when count >= @max_parameter_nodes,
-    do: :error
-
-  defp bounded_charlist_size([value | rest], count, size) do
-    if unicode_codepoint?(value) and is_list(rest) do
-      bounded_charlist_size(rest, count + 1, size + utf8_codepoint_size(value))
-    else
-      :not_charlist
-    end
-  end
-
-  defp bounded_charlist_size(_improper, _count, _size), do: :not_charlist
-
-  defp utf8_codepoint_size(value) when value <= 0x7F, do: 1
-  defp utf8_codepoint_size(value) when value <= 0x7FF, do: 2
-  defp utf8_codepoint_size(value) when value <= 0xFFFF, do: 3
-  defp utf8_codepoint_size(_value), do: 4
-
-  defp flat_charlist?([]), do: false
-
-  defp flat_charlist?(list) do
-    Enum.all?(list, &unicode_codepoint?/1)
-  end
-
-  defp log_safe_charlist(list, key_entities) do
-    if text_contains_pii?(List.to_string(list), value_entities(key_entities)) do
-      @filtered
-    else
-      list
-    end
-  end
-
-  defp value_entities(:filter_all), do: :filter_all
-  defp value_entities(key_entities), do: [:domain | key_entities]
-
-  defp scalar_text(value) when is_atom(value), do: Atom.to_string(value)
-  defp scalar_text(value) when is_number(value), do: to_string(value)
-
-  defp unicode_codepoint?(value) when is_integer(value) do
-    value >= 0 and value <= 0x10FFFF and value not in 0xD800..0xDFFF
-  end
-
-  defp unicode_codepoint?(_value), do: false
-
-  defp key_entities do
-    case Obscura.Profile.fetch(:fast) do
-      {:ok, profile} -> profile.supported_entities -- [:domain]
-      {:error, _reason} -> :filter_all
-    end
-  end
-
-  defp safe_method(method, _key_entities) when method in @standard_methods, do: method
-
-  defp safe_method(method, key_entities)
-       when is_binary(method) and byte_size(method) <= @max_method_bytes do
-    if http_token?(method) and
-         not text_contains_pii?(method, value_entities(key_entities)),
-       do: method,
-       else: "[FILTERED METHOD]"
-  end
-
-  defp safe_method(_method, _key_entities), do: "[FILTERED METHOD]"
-
-  defp http_token?(<<>>), do: false
-  defp http_token?(method), do: http_token_bytes?(method)
-
-  defp http_token_bytes?(<<>>), do: true
-
-  defp http_token_bytes?(<<byte, rest::binary>>) do
-    if http_token_byte?(byte),
-      do: http_token_bytes?(rest),
-      else: false
-  end
-
-  defp http_token_byte?(byte)
-       when byte in ?0..?9 or byte in ?A..?Z or byte in ?a..?z,
-       do: true
-
-  defp http_token_byte?(byte)
-       when byte in [?!, ?#, ?$, ?%, ?&, ?', ?*, ?+, ?-, ?., ?^, ?_, ?`, ?|, ?~],
-       do: true
-
-  defp http_token_byte?(_byte), do: false
 
   defp route(metadata) do
     case Map.get(metadata, :route) do

--- a/lib/obscura/phoenix/logger.ex
+++ b/lib/obscura/phoenix/logger.ex
@@ -10,6 +10,9 @@ defmodule Obscura.Phoenix.Logger do
 
       config :phoenix, :logger, false
 
+  Startup fails if a corresponding Phoenix default HTTP logger remains
+  attached, preventing raw and sanitized request records from running together.
+
   Place `Obscura.Phoenix.Plug` after `Plug.Parsers` and before the router:
 
       plug Obscura.Phoenix.Plug,
@@ -43,6 +46,10 @@ defmodule Obscura.Phoenix.Logger do
     [:phoenix, :endpoint, :stop],
     [:phoenix, :error_rendered],
     [:phoenix, :router_dispatch, :start]
+  ]
+
+  @unsafe_default_logger_events [
+    [:phoenix, :endpoint, :start] | @events
   ]
 
   @filtered "[FILTERED]"
@@ -223,6 +230,7 @@ defmodule Obscura.Phoenix.Logger do
 
   defp handler_config(opts) do
     with :ok <- PhoenixLog.validate_options(opts, @allowed_options),
+         :ok <- PhoenixLog.validate_default_logger(@unsafe_default_logger_events),
          :ok <- validate_assign(Keyword.get(opts, :assign, :obscura_redacted)),
          :ok <- PhoenixLog.validate_inspect_opts(Keyword.get(opts, :inspect_opts, [])) do
       name = Keyword.get(opts, :name, __MODULE__)

--- a/lib/obscura/phoenix/plug.ex
+++ b/lib/obscura/phoenix/plug.ex
@@ -1,23 +1,46 @@
 defmodule Obscura.Phoenix.Plug do
   @moduledoc """
   Plug-compatible request sanitization helper.
+
+  Integration options are validated and normalized by `init/1`. Invalid modes,
+  fields, assign names, telemetry flags, and declarative redaction options fail
+  during Plug initialization rather than during a request.
   """
 
   import Plug.Conn
 
+  alias Obscura.Analyzer.Options
+  alias Obscura.Anonymizer
   alias Obscura.Telemetry
+
+  @initialized_option :__obscura_phoenix_plug_initialized__
+  @integration_options [:assign, :fields, :mode]
+  @supported_fields [:params, :req_headers]
+  @supported_modes [:assign_redacted, :replace, :disabled]
 
   @doc false
   @spec init(keyword()) :: keyword()
-  def init(opts), do: opts
+  def init(opts) do
+    case normalize_options(opts) do
+      {:ok, normalized} ->
+        normalized
+
+      {:error, {option, reason}} ->
+        raise ArgumentError,
+              "invalid Obscura.Phoenix.Plug option #{inspect(option)}: #{reason}"
+    end
+  end
 
   @doc false
   @spec call(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
-  def call(conn, opts) do
+  def call(conn, [{@initialized_option, true} | _rest] = opts), do: do_call(conn, opts)
+  def call(conn, opts), do: call(conn, init(opts))
+
+  defp do_call(conn, opts) do
     start = System.monotonic_time()
-    mode = Keyword.get(opts, :mode, :assign_redacted)
-    fields = Keyword.get(opts, :fields, [:params])
-    assign = Keyword.get(opts, :assign, :obscura_redacted)
+    mode = Keyword.fetch!(opts, :mode)
+    fields = Keyword.fetch!(opts, :fields)
+    assign = Keyword.fetch!(opts, :assign)
 
     {conn, redacted} =
       if mode == :disabled do
@@ -38,7 +61,8 @@ defmodule Obscura.Phoenix.Plug do
   end
 
   defp redact_fields(conn, fields, opts) do
-    Map.new(fields, &redact_field(conn, &1, opts))
+    redaction_opts = Keyword.drop(opts, [@initialized_option | @integration_options])
+    Map.new(fields, &redact_field(conn, &1, redaction_opts))
   end
 
   defp redact_field(conn, :params, opts) do
@@ -71,5 +95,77 @@ defmodule Obscura.Phoenix.Plug do
     {conn, redacted}
   end
 
-  defp apply_mode(redacted, conn, _mode, assign), do: {assign(conn, assign, redacted), redacted}
+  defp normalize_options(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      mode = Keyword.get(opts, :mode, :assign_redacted)
+      fields = Keyword.get(opts, :fields, [:params])
+      assign = Keyword.get(opts, :assign, :obscura_redacted)
+      telemetry = Keyword.get(opts, :telemetry, true)
+
+      with :ok <- validate_mode(mode),
+           {:ok, fields} <- normalize_fields(fields),
+           :ok <- validate_assign(assign),
+           :ok <- validate_telemetry(telemetry),
+           :ok <- validate_redaction_options(mode, opts) do
+        {:ok,
+         opts
+         |> Keyword.put(:mode, mode)
+         |> Keyword.put(:fields, fields)
+         |> Keyword.put(:assign, assign)
+         |> Keyword.put(:telemetry, telemetry)
+         |> Keyword.put(@initialized_option, true)}
+      end
+    else
+      {:error, {:options, "expected a keyword list"}}
+    end
+  end
+
+  defp normalize_options(_opts), do: {:error, {:options, "expected a keyword list"}}
+
+  defp validate_mode(mode) when mode in @supported_modes, do: :ok
+
+  defp validate_mode(_mode),
+    do: {:error, {:mode, "expected :assign_redacted, :replace, or :disabled"}}
+
+  defp normalize_fields(fields) when is_list(fields),
+    do: normalize_fields(fields, %{}, [])
+
+  defp normalize_fields(_fields), do: {:error, {:fields, "expected a proper list"}}
+
+  defp normalize_fields([], _seen, normalized), do: {:ok, Enum.reverse(normalized)}
+
+  defp normalize_fields([field | rest], seen, normalized) when field in @supported_fields do
+    if Map.has_key?(seen, field) do
+      normalize_fields(rest, seen, normalized)
+    else
+      normalize_fields(rest, Map.put(seen, field, true), [field | normalized])
+    end
+  end
+
+  defp normalize_fields([_field | _rest], _seen, _normalized),
+    do: {:error, {:fields, "contains an unsupported field"}}
+
+  defp normalize_fields(_improper, _seen, _normalized),
+    do: {:error, {:fields, "expected a proper list"}}
+
+  defp validate_assign(assign) when is_atom(assign), do: :ok
+  defp validate_assign(_assign), do: {:error, {:assign, "expected an atom"}}
+
+  defp validate_telemetry(telemetry) when is_boolean(telemetry), do: :ok
+  defp validate_telemetry(_telemetry), do: {:error, {:telemetry, "expected a boolean"}}
+
+  defp validate_redaction_options(:disabled, _opts), do: :ok
+
+  defp validate_redaction_options(_mode, opts) do
+    redaction_opts = Keyword.drop(opts, @integration_options)
+
+    with {:ok, _options} <- Options.new(redaction_opts),
+         {:ok, _operators} <- Anonymizer.validate_options(redaction_opts),
+         {:ok, _probe} <-
+           Obscura.Structured.redact(%{}, Keyword.put(redaction_opts, :telemetry, false)) do
+      :ok
+    else
+      _error -> {:error, {:redaction, "contains invalid redaction options"}}
+    end
+  end
 end

--- a/lib/obscura/phoenix/socket_logger.ex
+++ b/lib/obscura/phoenix/socket_logger.ex
@@ -21,7 +21,8 @@ defmodule Obscura.Phoenix.SocketLogger do
   Model-backed profiles and custom realtime callbacks are intentionally not
   accepted in this synchronous logging path. Parameter text above the fixed
   4 KiB realtime analysis budget is logged as `[FILTERED]` without running PII
-  recognition.
+  recognition. Structs and tuple-bearing terms, including keyword lists, also
+  fail closed without protocol dispatch.
   """
 
   use GenServer

--- a/lib/obscura/phoenix/socket_logger.ex
+++ b/lib/obscura/phoenix/socket_logger.ex
@@ -19,7 +19,9 @@ defmodule Obscura.Phoenix.SocketLogger do
        connect_params: {:redact, entities: [:email, :phone, :credit_card]}}
 
   Model-backed profiles and custom realtime callbacks are intentionally not
-  accepted in this synchronous logging path.
+  accepted in this synchronous logging path. Parameter text above the fixed
+  4 KiB realtime analysis budget is logged as `[FILTERED]` without running PII
+  recognition.
   """
 
   use GenServer

--- a/lib/obscura/phoenix/socket_logger.ex
+++ b/lib/obscura/phoenix/socket_logger.ex
@@ -1,0 +1,142 @@
+defmodule Obscura.Phoenix.SocketLogger do
+  @moduledoc """
+  Privacy-safe logging for Phoenix socket connection and drain events.
+
+  This opt-in telemetry handler replaces the socket portion of Phoenix's
+  default logger after `config :phoenix, :logger, false` disables it. Connection
+  parameters are omitted by default. `connect_info` is never logged.
+
+  Add the handler to the application supervision tree:
+
+      children = [
+        {Obscura.Phoenix.SocketLogger, connect_params: :omit}
+      ]
+
+  To include a bounded redacted copy of connection parameters, opt in to the
+  dependency-light `:fast` profile:
+
+      {Obscura.Phoenix.SocketLogger,
+       connect_params: {:redact, entities: [:email, :phone, :credit_card]}}
+
+  Model-backed profiles and custom realtime callbacks are intentionally not
+  accepted in this synchronous logging path.
+  """
+
+  use GenServer
+
+  alias Obscura.Internal.PhoenixLog
+
+  @events [[:phoenix, :socket_connected], [:phoenix, :socket_drain]]
+  @allowed_options [:connect_params, :inspect_opts, :name]
+
+  @doc "Starts the Phoenix socket telemetry handler."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    with :ok <- PhoenixLog.validate_options(opts, @allowed_options),
+         :ok <- PhoenixLog.validate_default_logger(@events),
+         inspect_opts = Keyword.get(opts, :inspect_opts, limit: 50, printable_limit: 500),
+         :ok <- PhoenixLog.validate_inspect_opts(inspect_opts),
+         {:ok, params_policy} <-
+           PhoenixLog.prepare_params_policy(
+             Keyword.get(opts, :connect_params, :omit),
+             inspect_opts
+           ) do
+      name = Keyword.get(opts, :name, __MODULE__)
+      handler_id = {__MODULE__, name, make_ref()}
+      detach_previous_handlers(name)
+
+      config = %{
+        handler_id: handler_id,
+        owner: self(),
+        params_policy: params_policy
+      }
+
+      case :telemetry.attach_many(handler_id, @events, &__MODULE__.handle_event/4, config) do
+        :ok -> {:ok, handler_id}
+        {:error, reason} -> {:stop, reason}
+      end
+    else
+      {:error, reason} -> {:stop, reason}
+    end
+  end
+
+  @doc false
+  @spec handle_event([atom()], map(), map(), map()) :: :ok
+  def handle_event(
+        event,
+        measurements,
+        metadata,
+        %{owner: owner, handler_id: handler_id} = config
+      ) do
+    PhoenixLog.dispatch(owner, handler_id, fn ->
+      dispatch(event, measurements, metadata, config)
+    end)
+  end
+
+  @impl true
+  def terminate(_reason, handler_id), do: :telemetry.detach(handler_id)
+
+  defp dispatch([:phoenix, :socket_connected], _measurements, %{log: false}, _config),
+    do: :ok
+
+  defp dispatch([:phoenix, :socket_connected], measurements, metadata, config) do
+    level = PhoenixLog.log_level(Map.get(metadata, :log), :info)
+
+    PhoenixLog.log(level, fn ->
+      [
+        connection_result(Map.get(metadata, :result)),
+        PhoenixLog.safe_identifier(Map.get(metadata, :user_socket)),
+        " in ",
+        PhoenixLog.duration(Map.get(measurements, :duration)),
+        "\n  Transport: ",
+        PhoenixLog.safe_identifier(Map.get(metadata, :transport)),
+        "\n  Serializer: ",
+        PhoenixLog.safe_identifier(Map.get(metadata, :serializer)),
+        "\n  Parameters: ",
+        PhoenixLog.render_params(Map.get(metadata, :params), config.params_policy)
+      ]
+    end)
+  end
+
+  defp dispatch([:phoenix, :socket_drain], _measurements, %{log: false}, _config),
+    do: :ok
+
+  defp dispatch([:phoenix, :socket_drain], measurements, metadata, _config) do
+    level = PhoenixLog.log_level(Map.get(metadata, :log), :info)
+
+    PhoenixLog.log(level, fn ->
+      [
+        "DRAINING ",
+        PhoenixLog.safe_count(Map.get(measurements, :count)),
+        " of ",
+        PhoenixLog.safe_count(Map.get(measurements, :total)),
+        " total connection(s) for socket ",
+        PhoenixLog.safe_identifier(Map.get(metadata, :socket)),
+        " every ",
+        PhoenixLog.safe_count(Map.get(metadata, :interval)),
+        "ms - round ",
+        PhoenixLog.safe_count(Map.get(measurements, :index)),
+        " of ",
+        PhoenixLog.safe_count(Map.get(measurements, :rounds))
+      ]
+    end)
+  end
+
+  defp dispatch(_event, _measurements, _metadata, _config), do: :ok
+
+  defp connection_result(:ok), do: "CONNECTED TO "
+  defp connection_result(:error), do: "REFUSED CONNECTION TO "
+  defp connection_result(_result), do: "SOCKET CONNECTION FOR "
+
+  defp detach_previous_handlers(name) do
+    PhoenixLog.detach_previous_handlers(@events, __MODULE__, name)
+  end
+end

--- a/priv/obscura/documented_examples.exs
+++ b/priv/obscura/documented_examples.exs
@@ -175,6 +175,12 @@
     "Plug-Compatible Helper" => [{:test, "test/obscura/phoenix/plug_test.exs"}],
     "Privacy-safe Phoenix request logging" => [
       {:test, "test/obscura/phoenix/logger_test.exs"}
+    ],
+    "Privacy-safe Phoenix socket logging" => [
+      {:test, "test/obscura/phoenix/realtime_logger_test.exs"}
+    ],
+    "Privacy-safe Phoenix channel logging" => [
+      {:test, "test/obscura/phoenix/realtime_logger_test.exs"}
     ]
   }
 }

--- a/priv/obscura/public_api.exs
+++ b/priv/obscura/public_api.exs
@@ -122,8 +122,10 @@
     },
     Obscura.Operator.Custom => %{callbacks: [apply: 3]},
     Obscura.Operator.Hash => %{functions: [verify: 2]},
+    Obscura.Phoenix.ChannelLogger => %{functions: [child_spec: 1, start_link: 0, start_link: 1]},
     Obscura.Phoenix.Logger => %{functions: [child_spec: 1, start_link: 0, start_link: 1]},
     Obscura.Phoenix.Plug => %{functions: [call: 2, init: 1]},
+    Obscura.Phoenix.SocketLogger => %{functions: [child_spec: 1, start_link: 0, start_link: 1]},
     Obscura.Profile => %{
       functions: [
         available?: 1,
@@ -247,7 +249,8 @@
     Obscura.Recognizer.Phone.ExPhoneNumberValidator =>
       "Optional parser adapter depends on ex_phone_number.",
     Obscura.Recognizer.PrivacyFilter.Native => "Native OpenMed recognizer remains experimental.",
-    Obscura.Tiktoken => "Tokenizer compatibility API is not yet part of the core release promise.",
+    Obscura.Tiktoken =>
+      "Tokenizer compatibility API is not yet part of the core release promise.",
     Obscura.Tiktoken.Encoding => "Encoding representation and low-level functions may change."
   },
   deprecated: %{},

--- a/test/obscura/documented_examples_test.exs
+++ b/test/obscura/documented_examples_test.exs
@@ -227,11 +227,22 @@ defmodule Obscura.DocumentedExamplesTest do
     assert metadata[:user] == "[EMAIL]"
     assert is_binary(elem(Obscura.Logger.safe_inspect(metadata, entities: [:email]), 1))
 
-    assert Plug.init(
+    plug_options =
+      Plug.init(
+        fields: [:params],
+        mode: :assign_redacted,
+        entities: [:email]
+      )
+
+    assert plug_options
+           |> Keyword.take([:fields, :mode, :assign, :telemetry, :entities])
+           |> Map.new() == %{
              fields: [:params],
              mode: :assign_redacted,
+             assign: :obscura_redacted,
+             telemetry: true,
              entities: [:email]
-           ) == [fields: [:params], mode: :assign_redacted, entities: [:email]]
+           }
   end
 
   test "operator guide examples match their schemas" do

--- a/test/obscura/phoenix/logger_test.exs
+++ b/test/obscura/phoenix/logger_test.exs
@@ -368,6 +368,7 @@ defmodule Obscura.Phoenix.LoggerTest do
     scenarios = [
       Map.new(1..65, fn index -> {"field_#{index}", "value"} end),
       %{String.duplicate("k", 4_097) => "oversized-key"},
+      %{"values" => List.duplicate("value", 128)},
       %{"values" => List.duplicate("value", 1_024)},
       %{"value" => String.duplicate("v", 65_537)},
       %{"value" => oversized_integer},

--- a/test/obscura/phoenix/logger_test.exs
+++ b/test/obscura/phoenix/logger_test.exs
@@ -36,10 +36,45 @@ defmodule Obscura.Phoenix.LoggerTest do
     plug(Router)
   end
 
+  defmodule Endpoint do
+    use Phoenix.Endpoint, otp_app: :obscura
+
+    plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
+    plug(Plug.Parsers, parsers: [:urlencoded])
+
+    plug(Obscura.Phoenix.Plug,
+      mode: :assign_redacted,
+      fields: [:params],
+      entities: [:email]
+    )
+
+    plug(Router)
+  end
+
   def disabled_log_level(_conn), do: false
 
   def failing_log_level(conn) do
     raise "log level failed for #{conn.request_path}"
+  end
+
+  setup_all do
+    previous_endpoint = Application.fetch_env(:obscura, Endpoint)
+
+    Application.put_env(:obscura, Endpoint,
+      secret_key_base: String.duplicate("b", 64),
+      server: false
+    )
+
+    start_supervised!(Endpoint)
+
+    on_exit(fn ->
+      case previous_endpoint do
+        {:ok, value} -> Application.put_env(:obscura, Endpoint, value)
+        :error -> Application.delete_env(:obscura, Endpoint)
+      end
+    end)
+
+    :ok
   end
 
   setup do
@@ -667,6 +702,56 @@ defmodule Obscura.Phoenix.LoggerTest do
     refute log =~ "secret-marker"
   end
 
+  test "logs redacted params through a real Phoenix endpoint" do
+    conn =
+      :post
+      |> conn(
+        "/users/jane@example.com",
+        "email=jane%40example.com&password=endpoint-secret-marker"
+      )
+      |> put_req_header("content-type", "application/x-www-form-urlencoded")
+
+    log =
+      capture_log(fn ->
+        response = Endpoint.call(conn, Endpoint.init([]))
+        assert response.status == 204
+      end)
+
+    assert log =~ "Processing POST with /users/:id"
+    assert log =~ ~s("email" => "[EMAIL]")
+    assert log =~ ~s("password" => "[REDACTED]")
+    assert log =~ "Sent 204 in "
+    refute log =~ "jane@example.com"
+    refute log =~ "endpoint-secret-marker"
+  end
+
+  test "startup refuses to coexist with Phoenix's raw HTTP logger" do
+    event = [:phoenix, :endpoint, :start]
+    handler_id = {Phoenix.Logger, event}
+    :telemetry.detach(handler_id)
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        event,
+        &__MODULE__.discard_telemetry_event/4,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    previous_trap_exit = Process.flag(:trap_exit, true)
+
+    try do
+      name = :"unsafe_http_logger_#{System.unique_integer([:positive])}"
+
+      assert {:error, {:unsafe_phoenix_logger_attached, ^event}} =
+               ObscuraLogger.start_link(name: name)
+    after
+      Process.flag(:trap_exit, previous_trap_exit)
+    end
+  end
+
   test "rejects invalid stable options during startup" do
     invalid_assign_name = :"invalid_assign_#{System.unique_integer([:positive])}"
     invalid_inspect_name = :"invalid_inspect_#{System.unique_integer([:positive])}"
@@ -731,4 +816,7 @@ defmodule Obscura.Phoenix.LoggerTest do
       message -> send(parent, message)
     end
   end
+
+  @doc false
+  def discard_telemetry_event(_event, _measurements, _metadata, _config), do: :ok
 end

--- a/test/obscura/phoenix/logger_test.exs
+++ b/test/obscura/phoenix/logger_test.exs
@@ -368,7 +368,6 @@ defmodule Obscura.Phoenix.LoggerTest do
     scenarios = [
       Map.new(1..65, fn index -> {"field_#{index}", "value"} end),
       %{String.duplicate("k", 4_097) => "oversized-key"},
-      %{"values" => List.duplicate("value", 128)},
       %{"values" => List.duplicate("value", 1_024)},
       %{"value" => String.duplicate("v", 65_537)},
       %{"value" => oversized_integer},
@@ -400,6 +399,20 @@ defmodule Obscura.Phoenix.LoggerTest do
       :erlang.trace(self(), false, [:call])
       Process.exit(tracer, :kill)
     end
+  end
+
+  test "does not charge pre-redacted binary values against the PII analysis budget" do
+    params = %{"values" => List.duplicate("value", 128)}
+
+    conn =
+      :post
+      |> conn("/users", params)
+      |> assign(:obscura_redacted, %{params: params})
+
+    log = capture_log(fn -> emit_router_dispatch(conn) end)
+
+    assert log =~ ~s(Parameters: %{"values" => ["value")
+    refute log =~ "Parameters: \"[FILTERED]\""
   end
 
   test "accepts a parameter graph at the key-count boundary" do

--- a/test/obscura/phoenix/logger_test.exs
+++ b/test/obscura/phoenix/logger_test.exs
@@ -461,6 +461,23 @@ defmodule Obscura.Phoenix.LoggerTest do
     refute log =~ "privacy@example.com"
   end
 
+  test "standard request logging keeps field-level handling for opaque map keys" do
+    secret = "opaque-key-secret@example.com"
+    params = %{{:opaque, secret} => "safe"}
+
+    conn =
+      :post
+      |> conn("/users")
+      |> Map.put(:params, params)
+      |> assign(:obscura_redacted, %{params: params})
+
+    log = capture_log(fn -> emit_router_dispatch(conn) end)
+
+    assert log =~ ~s("[FILTERED KEY 1]" => "safe")
+    refute log =~ ~s(Parameters: "[FILTERED]")
+    refute log =~ secret
+  end
+
   test "uses the fast profile key taxonomy without filtering dotted field names" do
     params = %{
       "Address: 123 Main Street" => "address-key",

--- a/test/obscura/phoenix/plug_test.exs
+++ b/test/obscura/phoenix/plug_test.exs
@@ -23,4 +23,67 @@ defmodule Obscura.Phoenix.PlugTest do
 
     assert conn.params["email"] == "[EMAIL]"
   end
+
+  test "init normalizes integration defaults and direct calls remain compatible" do
+    opts = ObscuraPlug.init(entities: [:email], telemetry: false)
+
+    assert opts[:mode] == :assign_redacted
+    assert opts[:fields] == [:params]
+    assert opts[:assign] == :obscura_redacted
+    assert opts[:telemetry] == false
+
+    conn =
+      :post
+      |> conn("/", %{email: "jane@example.com"})
+      |> ObscuraPlug.call(entities: [:email], telemetry: false)
+
+    assert conn.assigns.obscura_redacted.params["email"] == "[EMAIL]"
+  end
+
+  test "init rejects invalid integration configuration before requests run" do
+    invalid_options = [
+      [mode: :typo],
+      [fields: :params],
+      [fields: [:unsupported]],
+      [assign: "obscura_redacted"],
+      [telemetry: :enabled]
+    ]
+
+    for opts <- invalid_options do
+      assert_raise ArgumentError, ~r/invalid Obscura.Phoenix.Plug option/, fn ->
+        ObscuraPlug.init(opts)
+      end
+    end
+  end
+
+  test "init removes duplicate fields while preserving their order" do
+    opts = ObscuraPlug.init(fields: [:req_headers, :params, :req_headers])
+
+    assert opts[:fields] == [:req_headers, :params]
+  end
+
+  test "init validates redaction configuration without running a request" do
+    assert_raise ArgumentError,
+                 "invalid Obscura.Phoenix.Plug option :redaction: contains invalid redaction options",
+                 fn ->
+                   ObscuraPlug.init(max_depth: -1)
+                 end
+
+    assert_raise ArgumentError,
+                 "invalid Obscura.Phoenix.Plug option :redaction: contains invalid redaction options",
+                 fn ->
+                   ObscuraPlug.init(profile: :unknown_profile)
+                 end
+  end
+
+  test "request headers use the same initialized redaction configuration" do
+    conn =
+      :get
+      |> conn("/")
+      |> Plug.Conn.put_req_header("x-contact", "jane@example.com")
+      |> ObscuraPlug.call(fields: [:req_headers], entities: [:email])
+
+    assert conn.req_headers == [{"x-contact", "jane@example.com"}]
+    assert conn.assigns.obscura_redacted.req_headers["x-contact"] == "[EMAIL]"
+  end
 end

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -284,6 +284,55 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     assert channel_log =~ "HANDLED new_message ON warn-room:*"
   end
 
+  test "socket logger filters numeric PII atoms from Phoenix identifiers" do
+    start_socket_logger()
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:phoenix, :socket_connected],
+          %{duration: 1},
+          %{
+            log: :info,
+            params: %{},
+            result: :ok,
+            serializer: :"123456789",
+            transport: :"2025550188",
+            user_socket: :"4111111111111111"
+          }
+        )
+      end)
+
+    assert [_, _, _] = Regex.scan(~r/\[FILTERED IDENTIFIER\]/, log)
+    refute log =~ "4111111111111111"
+    refute log =~ "2025550188"
+    refute log =~ "123456789"
+  end
+
+  test "channel logger filters numeric PII atoms from Phoenix identifiers" do
+    start_channel_logger(topic_patterns: ["room:*"], events: ["new_message"])
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:phoenix, :channel_handled_in],
+          %{duration: 1},
+          %{
+            event: "new_message",
+            params: %{},
+            socket: %{
+              channel: :"4111111111111111",
+              private: %{log_handle_in: :info},
+              topic: "room:42"
+            }
+          }
+        )
+      end)
+
+    assert log =~ "HANDLED new_message ON room:* ([FILTERED IDENTIFIER])"
+    refute log =~ "4111111111111111"
+  end
+
   test "channel correlation emits only a validated UUID socket assign as metadata" do
     chat_id = "43ad7b8f-b62c-4e1b-8349-8c8ea0a72362"
 

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -6,6 +6,17 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
   alias Obscura.Phoenix.ChannelLogger
   alias Obscura.Phoenix.SocketLogger
 
+  defmodule ProtocolPayload do
+    defstruct [:observer, :secret]
+  end
+
+  defimpl Obscura.Redactable, for: ProtocolPayload do
+    def redact(value, _opts) do
+      send(value.observer, {:redactable_called, value.secret})
+      {:ok, %{"callback_output" => value.secret}, []}
+    end
+  end
+
   defmodule RoomChannel do
     use Phoenix.Channel, log_join: :info, log_handle_in: :info
 
@@ -512,6 +523,49 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     refute log =~ "[EMAIL]"
   end
 
+  test "real Phoenix channel treats struct parameters as opaque" do
+    start_channel_logger(
+      topic_patterns: ["room:*"],
+      events: ["new_message"],
+      handle_in_params: {:redact, entities: [:email]}
+    )
+
+    socket = joined_socket()
+    secret = String.duplicate("x", 1_000_000) <> "protocol-secret@example.test"
+    payload = %{"payload" => %ProtocolPayload{observer: self(), secret: secret}}
+
+    log =
+      capture_log(fn ->
+        ref = push(socket, "new_message", payload)
+        assert_reply(ref, :ok)
+      end)
+
+    assert log =~ ~s("payload" => "[FILTERED]")
+    refute log =~ "protocol-secret@example.test"
+    refute_receive {:redactable_called, _secret}
+  end
+
+  test "real Phoenix channel rejects keyword-list parameters before redaction" do
+    start_channel_logger(
+      topic_patterns: ["room:*"],
+      events: ["new_message"],
+      handle_in_params: {:redact, entities: [:email]}
+    )
+
+    socket = joined_socket()
+    dense = String.duplicate("person@example.test ", 3_000)
+
+    log =
+      capture_log(fn ->
+        ref = push(socket, "new_message", body: dense)
+        assert_reply(ref, :ok)
+      end)
+
+    assert log =~ "Parameters: [FILTERED]"
+    refute log =~ "person@example.test"
+    refute log =~ "[EMAIL]"
+  end
+
   test "realtime byte budget rejects dense payloads before structured analysis" do
     {:ok, policy} =
       PhoenixLog.prepare_params_policy(
@@ -540,11 +594,36 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
 
       assert_receive {^rejected_ref, "[FILTERED]"}
       refute_receive {:trace, ^worker, :call, {Obscura.Structured, :redact, _arguments}}
+
+      for params <- [[body: rejected["body"]], %{"payload" => [body: rejected["body"]]}] do
+        keyword_ref = make_ref()
+        send(worker, {:render, self(), keyword_ref, params})
+
+        assert_receive {^keyword_ref, "[FILTERED]"}
+        refute_receive {:trace, ^worker, :call, {Obscura.Structured, :redact, _arguments}}
+      end
     after
       :erlang.trace_pattern({Obscura.Structured, :redact, 2}, false, [])
       :erlang.trace(worker, false, [:call])
       send(worker, :stop)
     end
+  end
+
+  test "realtime redaction keeps structs opaque without protocol dispatch" do
+    {:ok, policy} =
+      PhoenixLog.prepare_params_policy(
+        {:redact, entities: [:email]},
+        limit: 50,
+        printable_limit: 500
+      )
+
+    secret = String.duplicate("x", 1_000_000) <> "injected-secret@example.test"
+    payload = %ProtocolPayload{observer: self(), secret: secret}
+
+    assert PhoenixLog.render_params(%{"payload" => payload}, policy) ==
+             ~s(%{"payload" => "[FILTERED]"})
+
+    refute_receive {:redactable_called, _secret}
   end
 
   test "channel logging excludes metadata inherited from the channel process" do

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -333,6 +333,52 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     refute log =~ "4111111111111111"
   end
 
+  test "realtime loggers filter structured PII hidden behind identifier prefixes" do
+    start_socket_logger()
+    start_channel_logger(topic_patterns: ["room:*"], events: ["new_message"])
+
+    socket_log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:phoenix, :socket_connected],
+          %{duration: 1},
+          %{
+            log: :info,
+            params: %{},
+            result: :ok,
+            serializer: :"secret.example.test",
+            transport: :phone_2025550188,
+            user_socket: :card_4111111111111111
+          }
+        )
+      end)
+
+    channel_log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:phoenix, :channel_handled_in],
+          %{duration: 1},
+          %{
+            event: "new_message",
+            params: %{},
+            socket: %{
+              channel: :"ssn_123-45-6789",
+              private: %{log_handle_in: :info},
+              topic: "room:42"
+            }
+          }
+        )
+      end)
+
+    assert [_, _, _] = Regex.scan(~r/\[FILTERED IDENTIFIER\]/, socket_log)
+    assert channel_log =~ "HANDLED new_message ON room:* ([FILTERED IDENTIFIER])"
+
+    refute socket_log =~ "4111111111111111"
+    refute socket_log =~ "2025550188"
+    refute socket_log =~ "secret.example.test"
+    refute channel_log =~ "123-45-6789"
+  end
+
   test "channel correlation emits only a validated UUID socket assign as metadata" do
     chat_id = "43ad7b8f-b62c-4e1b-8349-8c8ea0a72362"
 
@@ -909,6 +955,55 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
 
       refute inspect(result, limit: :infinity) =~ secret
     end
+  end
+
+  test "Phoenix keep filters are bounded and compiled before realtime events" do
+    Application.put_env(:phoenix, :filter_parameters, {:keep, ["request_id"]})
+
+    assert {:ok, %{filter: {:keep, %{"request_id" => true}}} = policy} =
+             PhoenixLog.prepare_params_policy({:redact, []}, [])
+
+    rendered =
+      PhoenixLog.render_params(
+        %{"request_id" => "visible-id", "security_answer" => "first-pet-name"},
+        policy
+      )
+
+    assert rendered =~ ~s("request_id" => "visible-id")
+    assert rendered =~ ~s("security_answer" => "[FILTERED]")
+    refute rendered =~ "first-pet-name"
+
+    boundary = for index <- 1..256, do: "k#{index}"
+    Application.put_env(:phoenix, :filter_parameters, {:keep, boundary})
+
+    assert {:ok, %{filter: {:keep, compiled}}} =
+             PhoenixLog.prepare_params_policy({:redact, []}, [])
+
+    assert map_size(compiled) == 256
+
+    Application.put_env(
+      :phoenix,
+      :filter_parameters,
+      {:keep, for(index <- 1..257, do: "k#{index}")}
+    )
+
+    assert {:error, {:invalid_option, :filter_parameters, :invalid_phoenix_configuration}} =
+             isolated_start(fn ->
+               SocketLogger.start_link(
+                 name: unique_name(:oversized_keep_filter),
+                 connect_params: {:redact, []}
+               )
+             end)
+
+    Application.put_env(:phoenix, :filter_parameters, {:keep, [:binary.copy("k", 4_097)]})
+
+    assert {:error, {:invalid_option, :filter_parameters, :invalid_phoenix_configuration}} =
+             isolated_start(fn ->
+               ChannelLogger.start_link(
+                 name: unique_name(:oversized_keep_filter_bytes),
+                 join_params: {:redact, []}
+               )
+             end)
   end
 
   test "unsafe configured topic patterns and event names are rejected" do

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -363,6 +363,14 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     refute log =~ "topic-secret@example.test"
   end
 
+  test "oversized raw topics fail closed before configured pattern matching" do
+    {:ok, patterns} = PhoenixLog.prepare_topic_patterns(["room:*"])
+    oversized_topic = "room:" <> :binary.copy("x", 1_000_000)
+
+    assert PhoenixLog.safe_topic("room:42", patterns) == "room:*"
+    assert PhoenixLog.safe_topic(oversized_topic, patterns) == "[FILTERED TOPIC]"
+  end
+
   test "channel payload redaction is explicit and bounded" do
     start_channel_logger(
       topic_patterns: ["room:*"],
@@ -585,6 +593,9 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
       assert {:error, {:invalid_option, :correlation, :invalid_metadata_key}} =
                PhoenixLog.prepare_correlation({:socket_assign, key, :uuid})
     end
+
+    assert {:error, {:invalid_option, :correlation, :invalid_metadata_key}} =
+             PhoenixLog.prepare_correlation({:socket_assign, :"4111111111111111", :uuid})
   end
 
   test "startup refuses to coexist with Phoenix's raw socket logger" do

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -2,6 +2,7 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
   use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
+  alias Obscura.Internal.PhoenixLog
   alias Obscura.Phoenix.ChannelLogger
   alias Obscura.Phoenix.SocketLogger
 
@@ -194,6 +195,47 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     refute log =~ "join-secret@example.test"
     refute log =~ "socket-id-secret@example.test"
     refute log =~ "assign-secret@example.test"
+  end
+
+  test "channel correlation emits only a validated UUID socket assign as metadata" do
+    chat_id = "43ad7b8f-b62c-4e1b-8349-8c8ea0a72362"
+
+    start_channel_logger(
+      topic_patterns: ["room:*"],
+      events: ["new_message"],
+      correlation: {:socket_assign, :chat_id, :uuid}
+    )
+
+    filter_id = unique_name(:correlation_capture)
+
+    :ok =
+      :logger.add_primary_filter(
+        filter_id,
+        {&__MODULE__.capture_logger_event/2, self()}
+      )
+
+    on_exit(fn -> :logger.remove_primary_filter(filter_id) end)
+
+    socket = socket(UserSocket, nil, %{chat_id: chat_id})
+
+    capture_log(fn ->
+      assert {:ok, %{}, %Phoenix.Socket{}} =
+               subscribe_and_join(socket, RoomChannel, "room:42", %{})
+    end)
+
+    assert_receive {:logger_event, %{meta: %{chat_id: ^chat_id}}}
+
+    {:ok, correlation} = PhoenixLog.prepare_correlation({:socket_assign, :chat_id, :uuid})
+
+    assert PhoenixLog.correlation_metadata(
+             %{assigns: %{chat_id: "not-a-uuid"}},
+             correlation,
+             true
+           ) ==
+             []
+
+    assert PhoenixLog.correlation_metadata(%{assigns: %{chat_id: chat_id}}, correlation, false) ==
+             []
   end
 
   test "real Phoenix channel messages allow configured events and omit payloads" do
@@ -409,6 +451,14 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
                  events: [<<0xC2, 0x9B>>]
                )
              end)
+
+    assert {:error, {:invalid_option, :correlation, :expected_omit_or_socket_assign}} =
+             isolated_start(fn ->
+               ChannelLogger.start_link(
+                 name: unique_name(:invalid_correlation),
+                 correlation: {:socket_assign, :chat_id, :text}
+               )
+             end)
   end
 
   test "startup refuses to coexist with Phoenix's raw socket logger" do
@@ -474,4 +524,10 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
 
   @doc false
   def discard_telemetry_event(_event, _measurements, _metadata, _config), do: :ok
+
+  @doc "Forwards Logger events to the test process without modifying them."
+  def capture_logger_event(event, test_pid) do
+    send(test_pid, {:logger_event, event})
+    event
+  end
 end

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -1,0 +1,477 @@
+defmodule Obscura.Phoenix.RealtimeLoggerTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+  alias Obscura.Phoenix.ChannelLogger
+  alias Obscura.Phoenix.SocketLogger
+
+  defmodule RoomChannel do
+    use Phoenix.Channel, log_join: :info, log_handle_in: :info
+
+    @impl true
+    def join(_topic, _params, socket), do: {:ok, socket}
+
+    @impl true
+    def handle_in("new_message", _params, socket), do: {:reply, :ok, socket}
+
+    def handle_in("metadata_test", _params, socket) do
+      :ok =
+        :logger.set_process_metadata(%{
+          request_id: "logger-metadata-secret@example.test"
+        })
+
+      {:reply, :ok, socket}
+    end
+
+    def handle_in(_event, _params, socket), do: {:reply, :ok, socket}
+  end
+
+  defmodule UserSocket do
+    use Phoenix.Socket
+
+    channel("room:*", RoomChannel)
+
+    @impl true
+    def connect(_params, socket, _connect_info), do: {:ok, socket}
+
+    @impl true
+    def id(_socket), do: nil
+  end
+
+  defmodule Endpoint do
+    use Phoenix.Endpoint, otp_app: :obscura
+
+    socket("/socket", UserSocket,
+      websocket: true,
+      longpoll: false
+    )
+  end
+
+  import Phoenix.ChannelTest
+
+  @endpoint Endpoint
+
+  setup_all do
+    {:ok, _applications} = Application.ensure_all_started(:phoenix_pubsub)
+    previous_endpoint = Application.fetch_env(:obscura, Endpoint)
+
+    Application.put_env(:obscura, Endpoint,
+      secret_key_base: String.duplicate("a", 64),
+      pubsub_server: Obscura.Phoenix.RealtimeLoggerTest.PubSub,
+      server: false
+    )
+
+    start_supervised!({Phoenix.PubSub, name: Obscura.Phoenix.RealtimeLoggerTest.PubSub})
+    start_supervised!(Endpoint)
+
+    on_exit(fn ->
+      case previous_endpoint do
+        {:ok, value} -> Application.put_env(:obscura, Endpoint, value)
+        :error -> Application.delete_env(:obscura, Endpoint)
+      end
+    end)
+
+    :ok
+  end
+
+  setup do
+    previous_filter_parameters = Application.fetch_env(:phoenix, :filter_parameters)
+    Application.delete_env(:phoenix, :filter_parameters)
+
+    on_exit(fn ->
+      case previous_filter_parameters do
+        {:ok, value} -> Application.put_env(:phoenix, :filter_parameters, value)
+        :error -> Application.delete_env(:phoenix, :filter_parameters)
+      end
+    end)
+
+    :ok
+  end
+
+  test "real Phoenix socket connections omit params and connect info" do
+    start_socket_logger()
+
+    log =
+      capture_log(fn ->
+        result =
+          connect(
+            UserSocket,
+            %{"email" => "socket-secret@example.test"},
+            connect_info: %{
+              peer_data: %{address: {127, 0, 0, 1}},
+              x_headers: [{"x-secret", "connect-info-secret@example.test"}]
+            }
+          )
+
+        assert {:ok, %Phoenix.Socket{}} = result
+      end)
+
+    assert log =~ "CONNECTED TO Obscura.Phoenix.RealtimeLoggerTest.UserSocket"
+    assert log =~ "Parameters: [OMITTED]"
+    refute log =~ "socket-secret@example.test"
+    refute log =~ "connect-info-secret@example.test"
+    refute log =~ "peer_data"
+  end
+
+  test "socket connection params require explicit bounded fast redaction" do
+    start_socket_logger(connect_params: {:redact, entities: [:email]})
+
+    log =
+      capture_log(fn ->
+        assert {:ok, %Phoenix.Socket{}} =
+                 connect(UserSocket, %{
+                   "email" => "socket-secret@example.test",
+                   "locale" => "en"
+                 })
+      end)
+
+    assert log =~ ~s("email" => "[EMAIL]")
+    assert log =~ ~s("locale" => "en")
+    refute log =~ "socket-secret@example.test"
+  end
+
+  test "oversized socket parameter graphs fail closed" do
+    start_socket_logger(connect_params: {:redact, entities: [:email]})
+
+    log =
+      capture_log(fn ->
+        assert {:ok, %Phoenix.Socket{}} =
+                 connect(UserSocket, %{"body" => String.duplicate("x", 65_537)})
+      end)
+
+    assert log =~ "Parameters: [FILTERED]"
+    refute log =~ String.duplicate("x", 100)
+  end
+
+  test "socket drain logs only typed operational fields" do
+    start_socket_logger()
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:phoenix, :socket_drain],
+          %{count: 4, total: 10, index: 1, rounds: 3},
+          %{
+            endpoint: :"endpoint-secret@example.test",
+            interval: 2_000,
+            log: :info,
+            socket: UserSocket
+          }
+        )
+      end)
+
+    assert log =~ "DRAINING 4 of 10 total connection(s)"
+    assert log =~ "Obscura.Phoenix.RealtimeLoggerTest.UserSocket"
+    assert log =~ "every 2000ms - round 1 of 3"
+    refute log =~ "endpoint-secret@example.test"
+  end
+
+  test "real Phoenix channel joins use configured topic patterns and omit payloads" do
+    start_channel_logger(topic_patterns: ["room:*"], events: ["new_message"])
+
+    socket =
+      socket(
+        UserSocket,
+        "socket-id-secret@example.test",
+        %{private_secret: "assign-secret@example.test"}
+      )
+
+    log =
+      capture_log(fn ->
+        assert {:ok, %{}, %Phoenix.Socket{}} =
+                 subscribe_and_join(
+                   socket,
+                   RoomChannel,
+                   "room:topic-secret@example.test",
+                   %{"email" => "join-secret@example.test"}
+                 )
+      end)
+
+    assert log =~ "JOINED room:*"
+    assert log =~ "Obscura.Phoenix.RealtimeLoggerTest.RoomChannel"
+    assert log =~ "Parameters: [OMITTED]"
+    refute log =~ "topic-secret@example.test"
+    refute log =~ "join-secret@example.test"
+    refute log =~ "socket-id-secret@example.test"
+    refute log =~ "assign-secret@example.test"
+  end
+
+  test "real Phoenix channel messages allow configured events and omit payloads" do
+    start_channel_logger(topic_patterns: ["room:*"], events: ["new_message"])
+    socket = joined_socket()
+
+    log =
+      capture_log(fn ->
+        ref = push(socket, "new_message", %{"email" => "message-secret@example.test"})
+        assert_reply(ref, :ok)
+      end)
+
+    assert log =~ "HANDLED new_message ON room:*"
+    assert log =~ "Parameters: [OMITTED]"
+    refute log =~ "message-secret@example.test"
+  end
+
+  test "unconfigured event names and topics fail closed" do
+    start_channel_logger(topic_patterns: ["safe:*"], events: ["new_message"])
+    socket = joined_socket("room:topic-secret@example.test")
+
+    log =
+      capture_log(fn ->
+        ref = push(socket, "event-secret@example.test", %{})
+        assert_reply(ref, :ok)
+      end)
+
+    assert log =~ "HANDLED [FILTERED EVENT] ON [FILTERED TOPIC]"
+    refute log =~ "event-secret@example.test"
+    refute log =~ "topic-secret@example.test"
+  end
+
+  test "channel payload redaction is explicit and bounded" do
+    start_channel_logger(
+      topic_patterns: ["room:*"],
+      events: ["new_message"],
+      join_params: {:redact, entities: [:email]},
+      handle_in_params: {:redact, entities: [:email]}
+    )
+
+    socket = socket(UserSocket, nil, %{})
+    token = make_ref()
+
+    join_log =
+      capture_log(fn ->
+        result =
+          subscribe_and_join(socket, RoomChannel, "room:42", %{
+            "email" => "join-secret@example.test",
+            "kind" => "support"
+          })
+
+        send(self(), {token, result})
+      end)
+
+    assert_receive {^token, {:ok, %{}, socket}}
+    assert join_log =~ ~s("email" => "[EMAIL]")
+    assert join_log =~ ~s("kind" => "support")
+    refute join_log =~ "join-secret@example.test"
+
+    log =
+      capture_log(fn ->
+        ref =
+          push(socket, "new_message", %{
+            "email" => "message-secret@example.test",
+            "body" => "hello"
+          })
+
+        assert_reply(ref, :ok)
+      end)
+
+    assert log =~ ~s("email" => "[EMAIL]")
+    assert log =~ ~s("body" => "hello")
+    refute log =~ "message-secret@example.test"
+  end
+
+  test "channel logging excludes metadata inherited from the channel process" do
+    start_channel_logger(topic_patterns: ["room:*"], events: ["metadata_test"])
+    socket = joined_socket()
+
+    log =
+      capture_log(fn ->
+        ref = push(socket, "metadata_test", %{})
+        assert_reply(ref, :ok)
+      end)
+
+    assert log =~ "HANDLED metadata_test ON room:*"
+    refute log =~ "logger-metadata-secret@example.test"
+    refute log =~ "request_id"
+  end
+
+  test "Phoenix internal topics and disabled channel levels remain silent" do
+    start_channel_logger(topic_patterns: ["phoenix:*"], events: ["heartbeat"])
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:phoenix, :channel_handled_in],
+          %{duration: 10},
+          %{
+            event: "heartbeat",
+            params: %{},
+            socket: %{
+              channel: RoomChannel,
+              private: %{log_handle_in: :info},
+              topic: "phoenix:heartbeat"
+            }
+          }
+        )
+
+        :telemetry.execute(
+          [:phoenix, :channel_handled_in],
+          %{duration: 10},
+          %{
+            event: "heartbeat",
+            params: %{},
+            socket: %{
+              channel: RoomChannel,
+              private: %{log_handle_in: false},
+              topic: "room:42"
+            }
+          }
+        )
+      end)
+
+    assert log == ""
+  end
+
+  test "malformed telemetry metadata cannot detach either handler" do
+    start_socket_logger()
+    start_channel_logger(topic_patterns: ["room:*"], events: ["new_message"])
+
+    capture_log(fn ->
+      :telemetry.execute(
+        [:phoenix, :socket_connected],
+        %{duration: "duration-secret@example.test"},
+        %{params: fn -> "opaque-secret@example.test" end, log: :info}
+      )
+
+      :telemetry.execute(
+        [:phoenix, :channel_handled_in],
+        %{duration: :invalid},
+        %{
+          event: "event-secret@example.test",
+          params: fn -> "opaque-secret@example.test" end,
+          socket: %{private: %{log_handle_in: :info}, topic: <<255>>}
+        }
+      )
+    end)
+
+    log =
+      capture_log(fn ->
+        assert {:ok, %Phoenix.Socket{}} = connect(UserSocket, %{})
+      end)
+
+    assert log =~ "CONNECTED TO Obscura.Phoenix.RealtimeLoggerTest.UserSocket"
+  end
+
+  test "realtime payload policies reject model profiles and custom callbacks" do
+    assert {:error, {:invalid_option, :params, :fast_profile_required}} =
+             isolated_start(fn ->
+               SocketLogger.start_link(
+                 name: unique_name(:invalid_profile),
+                 connect_params: {:redact, profile: :balanced}
+               )
+             end)
+
+    assert {:error, {:invalid_option, :recognizers, :unsupported_realtime_redaction_option}} =
+             isolated_start(fn ->
+               ChannelLogger.start_link(
+                 name: unique_name(:invalid_recognizer),
+                 join_params: {:redact, recognizers: [RoomChannel]}
+               )
+             end)
+
+    assert {:error, {:invalid_option, :operators, :unsupported_realtime_redaction_option}} =
+             isolated_start(fn ->
+               ChannelLogger.start_link(
+                 name: unique_name(:invalid_operator),
+                 handle_in_params: {:redact, operators: %{default: %{type: :custom}}}
+               )
+             end)
+  end
+
+  test "unsafe configured topic patterns and event names are rejected" do
+    assert {:error, {:invalid_option, :topic_patterns, :invalid_pattern}} =
+             isolated_start(fn ->
+               ChannelLogger.start_link(
+                 name: unique_name(:invalid_topic),
+                 topic_patterns: ["room:secret@example.test"]
+               )
+             end)
+
+    assert {:error, {:invalid_option, :topic_patterns, :invalid_pattern}} =
+             isolated_start(fn ->
+               ChannelLogger.start_link(
+                 name: unique_name(:multiple_wildcards),
+                 topic_patterns: ["room:**"]
+               )
+             end)
+
+    assert {:error, {:invalid_option, :events, :invalid_event}} =
+             isolated_start(fn ->
+               ChannelLogger.start_link(
+                 name: unique_name(:invalid_event),
+                 events: ["secret@example.test"]
+               )
+             end)
+
+    assert {:error, {:invalid_option, :events, :invalid_event}} =
+             isolated_start(fn ->
+               ChannelLogger.start_link(
+                 name: unique_name(:control_event),
+                 events: [<<0xC2, 0x9B>>]
+               )
+             end)
+  end
+
+  test "startup refuses to coexist with Phoenix's raw socket logger" do
+    event = [:phoenix, :socket_connected]
+    handler_id = {Phoenix.Logger, event}
+    :telemetry.detach(handler_id)
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        event,
+        &__MODULE__.discard_telemetry_event/4,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    assert {:error, {:unsafe_phoenix_logger_attached, ^event}} =
+             isolated_start(fn ->
+               SocketLogger.start_link(name: unique_name(:unsafe_default_logger))
+             end)
+  end
+
+  defp isolated_start(fun) do
+    caller = self()
+    token = make_ref()
+
+    {_pid, monitor} =
+      spawn_monitor(fn ->
+        Process.flag(:trap_exit, true)
+        send(caller, {token, fun.()})
+      end)
+
+    assert_receive {^token, result}
+    assert_receive {:DOWN, ^monitor, :process, _pid, :normal}
+    result
+  end
+
+  defp joined_socket(topic \\ "room:42", params \\ %{}) do
+    socket = socket(UserSocket, nil, %{private_secret: "assign-secret@example.test"})
+    token = make_ref()
+
+    capture_log(fn ->
+      send(self(), {token, subscribe_and_join(socket, RoomChannel, topic, params)})
+    end)
+
+    assert_receive {^token, {:ok, %{}, socket}}
+    socket
+  end
+
+  defp start_socket_logger(opts \\ []) do
+    name = unique_name(:socket_logger)
+    start_supervised!({SocketLogger, Keyword.put(opts, :name, name)})
+  end
+
+  defp start_channel_logger(opts) do
+    name = unique_name(:channel_logger)
+    start_supervised!({ChannelLogger, Keyword.put(opts, :name, name)})
+  end
+
+  defp unique_name(prefix),
+    do: String.to_atom("#{prefix}_#{System.unique_integer([:positive])}")
+
+  @doc false
+  def discard_telemetry_event(_event, _measurements, _metadata, _config), do: :ok
+end

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -27,10 +27,23 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     def handle_in(_event, _params, socket), do: {:reply, :ok, socket}
   end
 
+  defmodule JoinAssignChannel do
+    use Phoenix.Channel, log_join: :info, log_handle_in: :info
+
+    @chat_id "43ad7b8f-b62c-4e1b-8349-8c8ea0a72362"
+
+    @impl true
+    def join(_topic, _params, socket), do: {:ok, assign(socket, :chat_id, @chat_id)}
+
+    @impl true
+    def handle_in("new_message", _params, socket), do: {:reply, :ok, socket}
+  end
+
   defmodule UserSocket do
     use Phoenix.Socket
 
     channel("room:*", RoomChannel)
+    channel("join-assign:*", JoinAssignChannel)
 
     @impl true
     def connect(_params, socket, _connect_info), do: {:ok, socket}
@@ -236,6 +249,88 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
 
     assert PhoenixLog.correlation_metadata(%{assigns: %{chat_id: chat_id}}, correlation, false) ==
              []
+  end
+
+  test "join correlation uses the pre-join socket and later events use join assigns" do
+    chat_id = "43ad7b8f-b62c-4e1b-8349-8c8ea0a72362"
+
+    start_channel_logger(
+      topic_patterns: ["join-assign:*"],
+      events: ["new_message"],
+      correlation: {:socket_assign, :chat_id, :uuid}
+    )
+
+    filter_id = unique_name(:join_assign_correlation_capture)
+
+    :ok =
+      :logger.add_primary_filter(
+        filter_id,
+        {&__MODULE__.capture_logger_event/2, self()}
+      )
+
+    on_exit(fn -> :logger.remove_primary_filter(filter_id) end)
+
+    socket = socket(UserSocket, nil, %{})
+
+    token = make_ref()
+
+    capture_log(fn ->
+      send(
+        self(),
+        {token, subscribe_and_join(socket, JoinAssignChannel, "join-assign:42", %{})}
+      )
+    end)
+
+    assert_receive {:logger_event, %{meta: join_metadata}}
+    refute Map.has_key?(join_metadata, :chat_id)
+    assert_receive {^token, {:ok, %{}, %Phoenix.Socket{} = joined_socket}}
+
+    capture_log(fn ->
+      ref = push(joined_socket, "new_message", %{})
+      assert_reply(ref, :ok)
+    end)
+
+    assert_receive {:logger_event, %{meta: %{chat_id: ^chat_id}}}
+  end
+
+  test "disabled channel events do not evaluate correlation metadata" do
+    {:ok, correlation} =
+      PhoenixLog.prepare_correlation({:socket_assign, :chat_id, :uuid})
+
+    socket = %{
+      topic: "room:42",
+      channel: RoomChannel,
+      private: %{log_handle_in: false},
+      assigns: %{chat_id: "43ad7b8f-b62c-4e1b-8349-8c8ea0a72362"}
+    }
+
+    config = %{
+      correlation: correlation,
+      events: MapSet.new(["new_message"]),
+      handle_in_params: %{mode: :omit},
+      handler_id: make_ref(),
+      join_params: %{mode: :omit},
+      owner: self(),
+      topic_patterns: [{:prefix, "room:", "room:*"}]
+    }
+
+    :erlang.trace(self(), true, [:call])
+    :erlang.trace_pattern({PhoenixLog, :correlation_metadata, 3}, true, [:local])
+
+    try do
+      assert :ok =
+               ChannelLogger.handle_event(
+                 [:phoenix, :channel_handled_in],
+                 %{duration: 1},
+                 %{event: "new_message", params: %{}, socket: socket},
+                 config
+               )
+
+      refute_receive {:trace, _, :call, {PhoenixLog, :correlation_metadata, _}}
+    after
+      :erlang.trace_pattern({PhoenixLog, :correlation_metadata, 3}, false, [:local])
+      :erlang.trace(self(), false, [:call])
+    end
   end
 
   test "real Phoenix channel messages allow configured events and omit payloads" do
@@ -459,6 +554,37 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
                  correlation: {:socket_assign, :chat_id, :text}
                )
              end)
+
+    assert {:error, {:invalid_option, :correlation, :invalid_metadata_key}} =
+             isolated_start(fn ->
+               ChannelLogger.start_link(
+                 name: unique_name(:reserved_correlation),
+                 correlation: {:socket_assign, :gl, :uuid}
+               )
+             end)
+
+    for key <- [
+          :application,
+          :crash_reason,
+          :domain,
+          :erl_level,
+          :error_logger,
+          :file,
+          :function,
+          :gl,
+          :initial_call,
+          :line,
+          :logger_formatter,
+          :mfa,
+          :module,
+          :pid,
+          :registered_name,
+          :report_cb,
+          :time
+        ] do
+      assert {:error, {:invalid_option, :correlation, :invalid_metadata_key}} =
+               PhoenixLog.prepare_correlation({:socket_assign, key, :uuid})
+    end
   end
 
   test "startup refuses to coexist with Phoenix's raw socket logger" do

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -50,11 +50,22 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     def handle_in("new_message", _params, socket), do: {:reply, :ok, socket}
   end
 
+  defmodule WarnChannel do
+    use Phoenix.Channel, log_join: :warn, log_handle_in: :warn
+
+    @impl true
+    def join(_topic, _params, socket), do: {:ok, socket}
+
+    @impl true
+    def handle_in("new_message", _params, socket), do: {:reply, :ok, socket}
+  end
+
   defmodule UserSocket do
     use Phoenix.Socket
 
     channel("room:*", RoomChannel)
     channel("join-assign:*", JoinAssignChannel)
+    channel("warn-room:*", WarnChannel)
 
     @impl true
     def connect(_params, socket, _connect_info), do: {:ok, socket}
@@ -233,6 +244,44 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     refute log =~ "join-secret@example.test"
     refute log =~ "socket-id-secret@example.test"
     refute log =~ "assign-secret@example.test"
+  end
+
+  test "deprecated Phoenix warn levels emit as warning for sockets and real channels" do
+    assert PhoenixLog.log_level(:warn, :info) == :warning
+
+    start_socket_logger()
+    start_channel_logger(topic_patterns: ["warn-room:*"], events: ["new_message"])
+
+    socket_log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:phoenix, :socket_connected],
+          %{duration: 1},
+          %{
+            log: :warn,
+            params: %{},
+            result: :ok,
+            serializer: Phoenix.Socket.V2.JSONSerializer,
+            transport: :websocket,
+            user_socket: UserSocket
+          }
+        )
+      end)
+
+    socket = socket(UserSocket, nil, %{})
+
+    channel_log =
+      capture_log(fn ->
+        assert {:ok, %{}, joined_socket} =
+                 subscribe_and_join(socket, WarnChannel, "warn-room:42", %{})
+
+        ref = push(joined_socket, "new_message", %{})
+        assert_reply(ref, :ok)
+      end)
+
+    assert socket_log =~ "CONNECTED TO Obscura.Phoenix.RealtimeLoggerTest.UserSocket"
+    assert channel_log =~ "JOINED warn-room:*"
+    assert channel_log =~ "HANDLED new_message ON warn-room:*"
   end
 
   test "channel correlation emits only a validated UUID socket assign as metadata" do

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -465,6 +465,23 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     assert :binary.referenced_byte_size(emitted_event) == byte_size(emitted_event)
   end
 
+  test "configured topic patterns do not retain larger source binaries" do
+    pattern = "room:" <> String.duplicate("a", 94) <> "*"
+    source = String.duplicate("x", 1_000_000) <> pattern
+    borrowed_pattern = binary_part(source, 1_000_000, byte_size(pattern))
+
+    assert :binary.referenced_byte_size(borrowed_pattern) > byte_size(borrowed_pattern)
+
+    assert {:ok, [{:prefix, prefix, configured_pattern}] = patterns} =
+             PhoenixLog.prepare_topic_patterns([borrowed_pattern])
+
+    assert configured_pattern == pattern
+    refute :erts_debug.same(configured_pattern, borrowed_pattern)
+    assert :binary.referenced_byte_size(configured_pattern) == byte_size(configured_pattern)
+    assert :binary.referenced_byte_size(prefix) <= byte_size(configured_pattern)
+    assert PhoenixLog.safe_topic(String.trim_trailing(pattern, "*") <> "42", patterns) == pattern
+  end
+
   test "unconfigured event names and topics fail closed" do
     start_channel_logger(topic_patterns: ["safe:*"], events: ["new_message"])
     socket = joined_socket("room:topic-secret@example.test")
@@ -658,6 +675,41 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     end
   end
 
+  test "realtime redaction rejects opaque map keys before structured analysis" do
+    {:ok, policy} =
+      PhoenixLog.prepare_params_policy(
+        {:redact, entities: [:email]},
+        limit: 50,
+        printable_limit: 500
+      )
+
+    worker = spawn_link(fn -> render_params_loop(policy) end)
+
+    :erlang.trace(worker, true, [:call, {:tracer, self()}])
+    :erlang.trace_pattern({Obscura.Structured, :redact, 2}, true, [])
+
+    try do
+      opaque_params = [
+        %{{:opaque, "tuple-key-secret@example.test"} => "safe"},
+        %{%ProtocolPayload{observer: self(), secret: "struct-key-secret@example.test"} => "safe"}
+      ]
+
+      for params <- opaque_params do
+        render_ref = make_ref()
+        send(worker, {:render, self(), render_ref, params})
+
+        assert_receive {^render_ref, "[FILTERED]"}
+        refute_receive {:trace, ^worker, :call, {Obscura.Structured, :redact, _arguments}}
+      end
+    after
+      :erlang.trace_pattern({Obscura.Structured, :redact, 2}, false, [])
+      :erlang.trace(worker, false, [:call])
+      send(worker, :stop)
+    end
+
+    refute_receive {:redactable_called, _secret}
+  end
+
   test "realtime redaction keeps structs opaque without protocol dispatch" do
     {:ok, policy} =
       PhoenixLog.prepare_params_policy(
@@ -781,6 +833,33 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
                  handle_in_params: {:redact, operators: %{default: %{type: :custom}}}
                )
              end)
+  end
+
+  test "invalid Phoenix filter patterns fail startup without exposing their values" do
+    secret = "filter-secret@example.test"
+    Application.put_env(:phoenix, :filter_parameters, [secret, ""])
+
+    results = [
+      isolated_start(fn ->
+        SocketLogger.start_link(
+          name: unique_name(:invalid_socket_filter),
+          connect_params: {:redact, entities: [:email]}
+        )
+      end),
+      isolated_start(fn ->
+        ChannelLogger.start_link(
+          name: unique_name(:invalid_channel_filter),
+          join_params: {:redact, entities: [:email]}
+        )
+      end)
+    ]
+
+    for result <- results do
+      assert result ==
+               {:error, {:invalid_option, :filter_parameters, :invalid_phoenix_configuration}}
+
+      refute inspect(result, limit: :infinity) =~ secret
+    end
   end
 
   test "unsafe configured topic patterns and event names are rejected" do

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -157,6 +157,20 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     refute log =~ String.duplicate("x", 100)
   end
 
+  test "dense socket parameters over the realtime analysis budget fail closed" do
+    start_socket_logger(connect_params: {:redact, entities: [:email]})
+    dense = String.duplicate("person@example.test ", 400)
+
+    log =
+      capture_log(fn ->
+        assert {:ok, %Phoenix.Socket{}} = connect(UserSocket, %{"body" => dense})
+      end)
+
+    assert log =~ "Parameters: [FILTERED]"
+    refute log =~ "person@example.test"
+    refute log =~ "[EMAIL]"
+  end
+
   test "socket drain logs only typed operational fields" do
     start_socket_logger()
 
@@ -476,6 +490,63 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     refute log =~ ~s("values")
   end
 
+  test "dense channel payloads over the realtime analysis budget fail closed" do
+    start_channel_logger(
+      topic_patterns: ["room:*"],
+      events: ["new_message"],
+      handle_in_params: {:redact, entities: [:email]}
+    )
+
+    socket = joined_socket()
+    dense = String.duplicate("person@example.test ", 400)
+
+    log =
+      capture_log(fn ->
+        ref = push(socket, "new_message", %{"body" => dense})
+        assert_reply(ref, :ok)
+      end)
+
+    assert log =~ "HANDLED new_message ON room:*"
+    assert log =~ "Parameters: [FILTERED]"
+    refute log =~ "person@example.test"
+    refute log =~ "[EMAIL]"
+  end
+
+  test "realtime byte budget rejects dense payloads before structured analysis" do
+    {:ok, policy} =
+      PhoenixLog.prepare_params_policy(
+        {:redact, entities: [:email]},
+        limit: 50,
+        printable_limit: 500
+      )
+
+    accepted = %{"body" => String.duplicate("x", 4_092)}
+    rejected = %{"body" => String.duplicate("person@example.test ", 3_000)}
+    worker = spawn_link(fn -> render_params_loop(policy) end)
+
+    :erlang.trace(worker, true, [:call, {:tracer, self()}])
+    :erlang.trace_pattern({Obscura.Structured, :redact, 2}, true, [])
+
+    try do
+      accepted_ref = make_ref()
+      send(worker, {:render, self(), accepted_ref, accepted})
+
+      assert_receive {:trace, ^worker, :call, {Obscura.Structured, :redact, _arguments}}
+      assert_receive {^accepted_ref, accepted_rendering}
+      refute accepted_rendering == "[FILTERED]"
+
+      rejected_ref = make_ref()
+      send(worker, {:render, self(), rejected_ref, rejected})
+
+      assert_receive {^rejected_ref, "[FILTERED]"}
+      refute_receive {:trace, ^worker, :call, {Obscura.Structured, :redact, _arguments}}
+    after
+      :erlang.trace_pattern({Obscura.Structured, :redact, 2}, false, [])
+      :erlang.trace(worker, false, [:call])
+      send(worker, :stop)
+    end
+  end
+
   test "channel logging excludes metadata inherited from the channel process" do
     start_channel_logger(topic_patterns: ["room:*"], events: ["metadata_test"])
     socket = joined_socket()
@@ -742,6 +813,17 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
   defp start_channel_logger(opts) do
     name = unique_name(:channel_logger)
     start_supervised!({ChannelLogger, Keyword.put(opts, :name, name)})
+  end
+
+  defp render_params_loop(policy) do
+    receive do
+      {:render, caller, reference, params} ->
+        send(caller, {reference, PhoenixLog.render_params(params, policy)})
+        render_params_loop(policy)
+
+      :stop ->
+        :ok
+    end
   end
 
   defp unique_name(prefix),

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -306,7 +306,7 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
 
     config = %{
       correlation: correlation,
-      events: MapSet.new(["new_message"]),
+      events: %{"new_message" => "new_message"},
       handle_in_params: %{mode: :omit},
       handler_id: make_ref(),
       join_params: %{mode: :omit},
@@ -346,6 +346,49 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     assert log =~ "HANDLED new_message ON room:*"
     assert log =~ "Parameters: [OMITTED]"
     refute log =~ "message-secret@example.test"
+  end
+
+  test "allow-listed event labels do not retain client-frame binaries" do
+    configured_event = :binary.copy("e", 100)
+    source = :binary.copy("x", 1_000_000) <> configured_event
+    incoming_event = binary_part(source, 1_000_000, byte_size(configured_event))
+
+    assert :binary.referenced_byte_size(incoming_event) > byte_size(incoming_event)
+
+    start_channel_logger(topic_patterns: ["room:*"], events: [configured_event])
+
+    filter_id = unique_name(:event_ownership_capture)
+
+    :ok =
+      :logger.add_primary_filter(
+        filter_id,
+        {&__MODULE__.capture_logger_event/2, self()}
+      )
+
+    on_exit(fn -> :logger.remove_primary_filter(filter_id) end)
+
+    capture_log(fn ->
+      :telemetry.execute(
+        [:phoenix, :channel_handled_in],
+        %{duration: 1},
+        %{
+          event: incoming_event,
+          params: %{},
+          socket: %{
+            channel: RoomChannel,
+            private: %{log_handle_in: :info},
+            topic: "room:42"
+          }
+        }
+      )
+    end)
+
+    assert_receive {:logger_event,
+                    %{msg: {:string, ["HANDLED ", emitted_event | _message_segments]}}}
+
+    assert emitted_event == configured_event
+    refute :erts_debug.same(emitted_event, incoming_event)
+    assert :binary.referenced_byte_size(emitted_event) == byte_size(emitted_event)
   end
 
   test "unconfigured event names and topics fail closed" do
@@ -412,6 +455,25 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     assert log =~ ~s("email" => "[EMAIL]")
     assert log =~ ~s("body" => "hello")
     refute log =~ "message-secret@example.test"
+  end
+
+  test "channel payloads over the analysis-term limit fail closed" do
+    start_channel_logger(
+      topic_patterns: ["room:*"],
+      events: ["new_message"],
+      handle_in_params: {:redact, entities: [:email]}
+    )
+
+    socket = joined_socket()
+
+    log =
+      capture_log(fn ->
+        ref = push(socket, "new_message", %{"values" => List.duplicate("value", 128)})
+        assert_reply(ref, :ok)
+      end)
+
+    assert log =~ "Parameters: [FILTERED]"
+    refute log =~ ~s("values")
   end
 
   test "channel logging excludes metadata inherited from the channel process" do
@@ -554,6 +616,32 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
                  events: [<<0xC2, 0x9B>>]
                )
              end)
+
+    for {suffix, label} <- [
+          newline: "safe\nINJECTED",
+          carriage_return: "safe\rINJECTED",
+          tab: "safe\tINJECTED",
+          escape: "safe\e[31m",
+          bidi_override: "safe\u202Etxt",
+          zero_width: "safe\u200Btxt",
+          line_separator: "safe\u2028txt"
+        ] do
+      assert {:error, {:invalid_option, :events, :invalid_event}} =
+               isolated_start(fn ->
+                 ChannelLogger.start_link(
+                   name: unique_name(:"control_event_#{suffix}"),
+                   events: [label]
+                 )
+               end)
+
+      assert {:error, {:invalid_option, :topic_patterns, :invalid_pattern}} =
+               isolated_start(fn ->
+                 ChannelLogger.start_link(
+                   name: unique_name(:"control_topic_#{suffix}"),
+                   topic_patterns: [label]
+                 )
+               end)
+    end
 
     assert {:error, {:invalid_option, :correlation, :expected_omit_or_socket_assign}} =
              isolated_start(fn ->

--- a/test/obscura/phoenix/realtime_logger_test.exs
+++ b/test/obscura/phoenix/realtime_logger_test.exs
@@ -517,6 +517,42 @@ defmodule Obscura.Phoenix.RealtimeLoggerTest do
     refute log =~ "message-secret@example.test"
   end
 
+  test "sustained real socket and channel redaction stays responsive" do
+    socket_connections = 100
+    channel_events = 250
+    secret = "sustained-secret@example.test"
+
+    start_socket_logger(connect_params: {:redact, entities: [:email]})
+
+    start_channel_logger(
+      topic_patterns: ["room:*"],
+      events: ["new_message"],
+      handle_in_params: {:redact, entities: [:email]}
+    )
+
+    socket = joined_socket()
+    started_at = System.monotonic_time(:millisecond)
+
+    log =
+      capture_log(fn ->
+        for _index <- 1..socket_connections do
+          assert {:ok, %Phoenix.Socket{}} = connect(UserSocket, %{"email" => secret})
+        end
+
+        for _index <- 1..channel_events do
+          ref = push(socket, "new_message", %{"email" => secret})
+          assert_reply(ref, :ok)
+        end
+      end)
+
+    elapsed_ms = System.monotonic_time(:millisecond) - started_at
+
+    assert length(:binary.matches(log, "CONNECTED TO ")) == socket_connections
+    assert length(:binary.matches(log, "HANDLED new_message ON room:*")) == channel_events
+    assert elapsed_ms < 10_000
+    refute log =~ secret
+  end
+
   test "allow-listed event labels do not retain client-frame binaries" do
     configured_event = :binary.copy("e", 100)
     source = :binary.copy("x", 1_000_000) <> configured_event


### PR DESCRIPTION
## Summary

- add opt-in privacy-safe telemetry handlers for Phoenix socket connections, socket drains, channel joins, and incoming channel events
- omit realtime parameters by default, with bounded `:fast` redaction available explicitly
- emit only configured topic patterns and event labels, with optional validated UUID correlation metadata
- fail startup when the corresponding raw Phoenix logger remains attached
- harden the existing HTTP logger boundary and validate Plug configuration during initialization

## Privacy boundary

- `connect_info` is never logged
- raw channel topics and event names are never emitted
- malformed or oversized values fail closed
- model-backed profiles and custom callbacks are excluded from synchronous realtime logging
- controller, socket, and channel inputs remain unchanged

## Verification

- `mix quality`
- `mix test` (`829 passed`, `14 excluded`)
- real Phoenix endpoint integration coverage
- real Phoenix socket and channel interface coverage
- sustained regression case covering 100 socket connections and 250 channel events
- ExDoc generation and targeted documentation-link validation

## Deployment note

These handlers are opt-in replacements. Applications must disable Phoenix's default telemetry logger with `config :phoenix, :logger, false` before supervising the Obscura HTTP, socket, or channel handlers.