### PR TITLE
Support Elixir 1.17 through 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,30 @@ concurrency:
 
 jobs:
   base:
-    name: Base library and quality gates
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Current Elixir 1.20 / OTP 29 quality gates
+            lane: current
+            otp: 29.0.3
+            elixir: 1.20.2
+            command: mix ci.base
+            minimum_runtime: "0"
+          - name: Minimum Elixir 1.17 / OTP 27 compatibility
+            lane: minimum
+            otp: 27.3.4.15
+            elixir: 1.17.3
+            command: mix ci.minimum
+            minimum_runtime: "1"
     env:
       MIX_ENV: test
       MIX_HOME: ${{ github.workspace }}/.mix
       HEX_HOME: ${{ github.workspace }}/.hex
+      OBSCURA_MINIMUM_RUNTIME: ${{ matrix.minimum_runtime }}
     steps:
       - name: Check out source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -27,8 +44,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1
         with:
-          otp-version: 29.0.3
-          elixir-version: 1.20.2
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
 
       - name: Restore dependency and PLT cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -39,9 +56,9 @@ jobs:
             .mix
             .hex
             priv/plts
-          key: base-${{ runner.os }}-${{ hashFiles('.tool-versions', 'mix.exs', 'mix.lock') }}
+          key: base-${{ matrix.lane }}-${{ runner.os }}-otp-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-${{ hashFiles('mix.exs', 'mix.lock') }}
           restore-keys: |
-            base-${{ runner.os }}-
+            base-${{ matrix.lane }}-${{ runner.os }}-otp-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-
 
       - name: Install local Mix tools
         run: |
@@ -52,4 +69,15 @@ jobs:
         run: mix deps.get
 
       - name: Run dependency-light validation
-        run: mix ci.base
+        run: ${{ matrix.command }}
+
+      - name: Validate unpacked Hex package on the minimum runtime
+        if: ${{ matrix.lane == 'minimum' }}
+        run: |
+          package_dir="$RUNNER_TEMP/obscura-package"
+          mix hex.build --unpack --output "$package_dir"
+          cd "$RUNNER_TEMP"
+          OBSCURA_PACKAGE_DIR="$package_dir" MIX_ENV=prod mix run --no-mix-exs -e '
+            Mix.install([{:obscura, path: System.fetch_env!("OBSCURA_PACKAGE_DIR")}])
+            {:ok, [_result]} = Obscura.analyze("contact@example.com", entities: [:email])
+          '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,30 @@ jobs:
             otp: 29.0.3
             elixir: 1.20.2
             command: mix ci.base
-            minimum_runtime: "0"
+            compatibility_runtime: "0"
+          - name: Elixir 1.19 / OTP 28 compatibility
+            lane: elixir-1-19
+            otp: 28.5
+            elixir: 1.19.5
+            command: mix ci.compatibility
+            compatibility_runtime: "1"
+          - name: Elixir 1.18 / OTP 27 compatibility
+            lane: elixir-1-18
+            otp: 27.3.4.15
+            elixir: 1.18.4
+            command: mix ci.compatibility
+            compatibility_runtime: "1"
           - name: Minimum Elixir 1.17 / OTP 27 compatibility
             lane: minimum
             otp: 27.3.4.15
             elixir: 1.17.3
-            command: mix ci.minimum
-            minimum_runtime: "1"
+            command: mix ci.compatibility
+            compatibility_runtime: "1"
     env:
       MIX_ENV: test
       MIX_HOME: ${{ github.workspace }}/.mix
       HEX_HOME: ${{ github.workspace }}/.hex
-      OBSCURA_MINIMUM_RUNTIME: ${{ matrix.minimum_runtime }}
+      OBSCURA_COMPATIBILITY_RUNTIME: ${{ matrix.compatibility_runtime }}
     steps:
       - name: Check out source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Dependency-light CI
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -65,8 +67,6 @@ jobs:
           path: |
             deps
             _build
-            .mix
-            .hex
             priv/plts
           key: base-${{ matrix.lane }}-${{ runner.os }}-otp-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-${{ hashFiles('mix.exs', 'mix.lock') }}
           restore-keys: |
@@ -79,6 +79,9 @@ jobs:
 
       - name: Fetch dependencies
         run: mix deps.get
+
+      - name: Remove compiled application files
+        run: mix clean
 
       - name: Run dependency-light validation
         run: ${{ matrix.command }}

--- a/.github/workflows/optional-compatibility.yml
+++ b/.github/workflows/optional-compatibility.yml
@@ -25,17 +25,27 @@ jobs:
             lane: current
             otp: 29.0.3
             elixir: 1.20.2
-            minimum_runtime: "0"
+            compatibility_runtime: "0"
+          - name: Elixir 1.19 / OTP 28
+            lane: elixir-1-19
+            otp: 28.5
+            elixir: 1.19.5
+            compatibility_runtime: "1"
+          - name: Elixir 1.18 / OTP 27
+            lane: elixir-1-18
+            otp: 27.3.4.15
+            elixir: 1.18.4
+            compatibility_runtime: "1"
           - name: minimum Elixir 1.17 / OTP 27
             lane: minimum
             otp: 27.3.4.15
             elixir: 1.17.3
-            minimum_runtime: "1"
+            compatibility_runtime: "1"
     env:
       MIX_ENV: test
       MIX_HOME: ${{ github.workspace }}/.mix
       HEX_HOME: ${{ github.workspace }}/.hex
-      OBSCURA_MINIMUM_RUNTIME: ${{ matrix.minimum_runtime }}
+      OBSCURA_COMPATIBILITY_RUNTIME: ${{ matrix.compatibility_runtime }}
     steps:
       - name: Check out source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/optional-compatibility.yml
+++ b/.github/workflows/optional-compatibility.yml
@@ -14,13 +14,28 @@ concurrency:
 
 jobs:
   optional:
-    name: Parser, HTTP, Nx, GLiNER, and checkpoint contracts
+    name: Optional contracts (${{ matrix.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: current Elixir 1.20 / OTP 29
+            lane: current
+            otp: 29.0.3
+            elixir: 1.20.2
+            minimum_runtime: "0"
+          - name: minimum Elixir 1.17 / OTP 27
+            lane: minimum
+            otp: 27.3.4.15
+            elixir: 1.17.3
+            minimum_runtime: "1"
     env:
       MIX_ENV: test
       MIX_HOME: ${{ github.workspace }}/.mix
       HEX_HOME: ${{ github.workspace }}/.hex
+      OBSCURA_MINIMUM_RUNTIME: ${{ matrix.minimum_runtime }}
     steps:
       - name: Check out source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -28,8 +43,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1
         with:
-          otp-version: 29.0.3
-          elixir-version: 1.20.2
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
 
       - name: Restore dependency cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -39,7 +54,7 @@ jobs:
             _build
             .mix
             .hex
-          key: optional-${{ runner.os }}-${{ hashFiles('.tool-versions', 'mix.exs', 'mix.lock') }}
+          key: optional-${{ matrix.lane }}-${{ runner.os }}-otp-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-${{ hashFiles('mix.exs', 'mix.lock') }}
 
       - name: Install tools and dependencies
         run: |

--- a/.github/workflows/optional-compatibility.yml
+++ b/.github/workflows/optional-compatibility.yml
@@ -62,8 +62,6 @@ jobs:
           path: |
             deps
             _build
-            .mix
-            .hex
           key: optional-${{ matrix.lane }}-${{ runner.os }}-otp-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-${{ hashFiles('mix.exs', 'mix.lock') }}
 
       - name: Install tools and dependencies
@@ -71,6 +69,9 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get
+
+      - name: Remove compiled application files
+        run: mix clean
 
       - name: Run optional compatibility suite
         run: mix ci.optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Obscura are documented in this file.
 ## Unreleased
 
 - Lowered the minimum supported Elixir version from 1.20 to 1.17 and added
-  minimum/current Elixir and Erlang/OTP compatibility lanes.
+  per-minor Elixir and Erlang/OTP compatibility lanes.
 - Added opt-in privacy-safe Phoenix socket and channel telemetry loggers with
   omission-first payload policies, configured topic patterns and event names,
   bounded `:fast` redaction, and raw-default-logger conflict detection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Obscura are documented in this file.
 
 ## Unreleased
 
+- Lowered the minimum supported Elixir version from 1.20 to 1.17 and added
+  minimum/current Elixir and Erlang/OTP compatibility lanes.
 - Added opt-in privacy-safe Phoenix socket and channel telemetry loggers with
   omission-first payload policies, configured topic patterns and event names,
   bounded `:fast` redaction, and raw-default-logger conflict detection.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ recognition. Obscura does not require a hosted recognition service.
 
 ## Installation
 
+Obscura supports Elixir 1.17 and later. CI validates the minimum supported
+runtime on Elixir 1.17.3 with Erlang/OTP 27 and the current development runtime
+on Elixir 1.20.2 with Erlang/OTP 29.
+
 Add Obscura to an Elixir project:
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ recognition. Obscura does not require a hosted recognition service.
 
 ## Installation
 
-Obscura supports Elixir 1.17 and later. CI validates the minimum supported
-runtime on Elixir 1.17.3 with Erlang/OTP 27 and the current development runtime
-on Elixir 1.20.2 with Erlang/OTP 29.
+Obscura supports Elixir 1.17 and later. CI validates every supported Elixir
+minor from 1.17 through 1.20 against a representative Erlang/OTP generation.
 
 Add Obscura to an Elixir project:
 

--- a/docs/ci-and-model-validation.md
+++ b/docs/ci-and-model-validation.md
@@ -5,36 +5,40 @@ accelerator validation.
 
 ## Supported Runtime Matrix
 
-Obscura supports Elixir 1.17 and later. Pull-request CI validates both ends of
-the actively maintained matrix:
+Obscura supports Elixir 1.17 and later. Pull-request CI validates every accepted
+Elixir minor with one representative Erlang/OTP generation:
 
 | Lane | Elixir | Erlang/OTP | Purpose |
 | --- | --- | --- | --- |
-| Minimum | 1.17.3 | 27.3.4.15 | Compile, ordinary tests, documentation-link checks, and unpacked Hex-package validation |
+| Minimum | 1.17.3 | 27.3.4.15 | Compatibility gate and unpacked Hex-package validation |
+| Intermediate | 1.18.4 | 27.3.4.15 | Compatibility gate |
+| Intermediate | 1.19.5 | 28.5 | Compatibility gate |
 | Current | 1.20.2 | 29.0.3 | Complete dependency-light quality and evidence gates |
 
 Elixir 1.17 officially supports OTP 25 through 27. OTP 27 is used for the
 minimum lane because it is the newest supported OTP generation for that Elixir
-release. Scheduled optional-dependency compatibility runs on both runtime
-pairs. Pages and controlled accelerator workflows remain on the current pair;
-those jobs validate publication or provisioned infrastructure rather than the
-minimum package runtime.
+release. Elixir 1.18 remains on OTP 27, Elixir 1.19 advances to OTP 28, and the
+current Elixir 1.20 lane uses OTP 29. Scheduled optional-dependency
+compatibility runs on all four pairs. Pages and controlled accelerator
+workflows remain on the current pair; those jobs validate publication or
+provisioned infrastructure rather than package compatibility.
 
-The minimum lane sets `OBSCURA_MINIMUM_RUNTIME=1` to omit current-only lint,
-type-analysis, and Syntect documentation tooling from the project dependency
-graph. It retains the complete runtime dependency graph, ordinary test
-dependencies, Phoenix integration tests, and optional Nx/Bumblebee contracts.
-Those omitted development tools require a newer Elixir version but are not
-dependencies of downstream Obscura applications.
+Compatibility lanes set `OBSCURA_COMPATIBILITY_RUNTIME=1` to omit current-only
+lint, type-analysis, and Syntect documentation tooling from the project
+dependency graph. Elixir versions below 1.18 omit those tools automatically for
+local development. The compatibility graph retains all runtime dependencies,
+ordinary test dependencies, Phoenix integration tests, and optional
+Nx/Bumblebee contracts. The omitted tools are not dependencies of downstream
+Obscura applications.
 
 ## Tier 1: Pull Requests
 
 Every push and pull request runs without EXLA, Emily, Ortex, model downloads,
 or external services. The current-runtime lane checks formatting, warnings,
 unit/fixture behavior, authoritative manifest integrity, static analysis, and
-documentation. The minimum-runtime lane compiles with warnings as errors, runs
-the ordinary test suite, verifies documentation links, and compiles and
-smoke-tests the unpacked Hex package.
+documentation. Each compatibility lane compiles with warnings as errors, runs
+the ordinary test suite, and verifies documentation links. The minimum lane
+also compiles and smoke-tests the unpacked Hex package.
 The lockfile hygiene subprocess fetches and evaluates the union of conditional
 optional dependency declarations so Mix can inspect their transitive graphs,
 but it does not compile or execute those adapters.
@@ -45,10 +49,10 @@ Local equivalent:
 mix ci.base
 ```
 
-Run the minimum-runtime subset under Elixir 1.17.3 and OTP 27 with:
+Run the compatibility subset under any supported Elixir/OTP pair with:
 
 ```sh
-mix ci.minimum
+mix ci.compatibility
 ```
 
 ## Tier 2: Optional Compatibility
@@ -123,8 +127,8 @@ this document describes their intended boundaries and local reproduction.
 
 | Workflow | Trigger | Runner | Local command |
 | --- | --- | --- | --- |
-| `ci.yml` | every push and pull request | GitHub-hosted Ubuntu, Elixir 1.17/OTP 27 and Elixir 1.20/OTP 29 | `mix ci.minimum` and `mix ci.base` |
-| `optional-compatibility.yml` | weekly and manual | GitHub-hosted Ubuntu, minimum and current runtime pairs | `mix ci.optional` |
+| `ci.yml` | every push and pull request | GitHub-hosted Ubuntu, Elixir 1.17 through 1.20 with representative OTP generations | `mix ci.compatibility` and `mix ci.base` |
+| `optional-compatibility.yml` | weekly and manual | GitHub-hosted Ubuntu, all supported Elixir minors | `mix ci.optional` |
 | `model-validation.yml` Apple | weekly/manual when enabled | `[self-hosted, macOS, ARM64, obscura-metal]` | `mix ci.real_model_smoke` with Emily environment |
 | `model-validation.yml` EXLA | weekly/manual when enabled | `[self-hosted, Linux, X64, obscura-exla]` | `mix ci.real_model_smoke` with EXLA environment |
 | `model-validation.yml` GLiNER | weekly/manual when enabled | `[self-hosted, macOS, ARM64, obscura-ortex]` | tagged GLiNER Ortex test |

--- a/docs/ci-and-model-validation.md
+++ b/docs/ci-and-model-validation.md
@@ -3,11 +3,38 @@
 Obscura separates dependency-light correctness from optional model and
 accelerator validation.
 
+## Supported Runtime Matrix
+
+Obscura supports Elixir 1.17 and later. Pull-request CI validates both ends of
+the actively maintained matrix:
+
+| Lane | Elixir | Erlang/OTP | Purpose |
+| --- | --- | --- | --- |
+| Minimum | 1.17.3 | 27.3.4.15 | Compile, ordinary tests, documentation-link checks, and unpacked Hex-package validation |
+| Current | 1.20.2 | 29.0.3 | Complete dependency-light quality and evidence gates |
+
+Elixir 1.17 officially supports OTP 25 through 27. OTP 27 is used for the
+minimum lane because it is the newest supported OTP generation for that Elixir
+release. Scheduled optional-dependency compatibility runs on both runtime
+pairs. Pages and controlled accelerator workflows remain on the current pair;
+those jobs validate publication or provisioned infrastructure rather than the
+minimum package runtime.
+
+The minimum lane sets `OBSCURA_MINIMUM_RUNTIME=1` to omit current-only lint,
+type-analysis, and Syntect documentation tooling from the project dependency
+graph. It retains the complete runtime dependency graph, ordinary test
+dependencies, Phoenix integration tests, and optional Nx/Bumblebee contracts.
+Those omitted development tools require a newer Elixir version but are not
+dependencies of downstream Obscura applications.
+
 ## Tier 1: Pull Requests
 
 Every push and pull request runs without EXLA, Emily, Ortex, model downloads,
-or external services. It checks formatting, warnings, unit/fixture behavior,
-authoritative manifest integrity, static analysis, and documentation.
+or external services. The current-runtime lane checks formatting, warnings,
+unit/fixture behavior, authoritative manifest integrity, static analysis, and
+documentation. The minimum-runtime lane compiles with warnings as errors, runs
+the ordinary test suite, verifies documentation links, and compiles and
+smoke-tests the unpacked Hex package.
 The lockfile hygiene subprocess fetches and evaluates the union of conditional
 optional dependency declarations so Mix can inspect their transitive graphs,
 but it does not compile or execute those adapters.
@@ -16,6 +43,12 @@ Local equivalent:
 
 ```sh
 mix ci.base
+```
+
+Run the minimum-runtime subset under Elixir 1.17.3 and OTP 27 with:
+
+```sh
+mix ci.minimum
 ```
 
 ## Tier 2: Optional Compatibility
@@ -90,8 +123,8 @@ this document describes their intended boundaries and local reproduction.
 
 | Workflow | Trigger | Runner | Local command |
 | --- | --- | --- | --- |
-| `ci.yml` | every push and pull request | GitHub-hosted Ubuntu | `mix ci.base` |
-| `optional-compatibility.yml` | weekly and manual | GitHub-hosted Ubuntu | `mix ci.optional` |
+| `ci.yml` | every push and pull request | GitHub-hosted Ubuntu, Elixir 1.17/OTP 27 and Elixir 1.20/OTP 29 | `mix ci.minimum` and `mix ci.base` |
+| `optional-compatibility.yml` | weekly and manual | GitHub-hosted Ubuntu, minimum and current runtime pairs | `mix ci.optional` |
 | `model-validation.yml` Apple | weekly/manual when enabled | `[self-hosted, macOS, ARM64, obscura-metal]` | `mix ci.real_model_smoke` with Emily environment |
 | `model-validation.yml` EXLA | weekly/manual when enabled | `[self-hosted, Linux, X64, obscura-exla]` | `mix ci.real_model_smoke` with EXLA environment |
 | `model-validation.yml` GLiNER | weekly/manual when enabled | `[self-hosted, macOS, ARM64, obscura-ortex]` | tagged GLiNER Ortex test |

--- a/docs/ci-and-model-validation.md
+++ b/docs/ci-and-model-validation.md
@@ -23,6 +23,13 @@ compatibility runs on all four pairs. Pages and controlled accelerator
 workflows remain on the current pair; those jobs validate publication or
 provisioned infrastructure rather than package compatibility.
 
+Dependency and build caches are isolated by operating system, Elixir, OTP,
+and lockfile. After a cache restore, CI removes Obscura's compiled application
+files while retaining compiled dependencies. Compilation and tests then run in
+separate Mix processes so compile-time changes to process-global state cannot
+affect the test environment. A cold cache and a warm cache must produce the
+same result.
+
 Compatibility lanes set `OBSCURA_COMPATIBILITY_RUNTIME=1` to omit current-only
 lint, type-analysis, and Syntect documentation tooling from the project
 dependency graph. Elixir versions below 1.18 omit those tools automatically for
@@ -33,12 +40,12 @@ Obscura applications.
 
 ## Tier 1: Pull Requests
 
-Every push and pull request runs without EXLA, Emily, Ortex, model downloads,
-or external services. The current-runtime lane checks formatting, warnings,
-unit/fixture behavior, authoritative manifest integrity, static analysis, and
-documentation. Each compatibility lane compiles with warnings as errors, runs
-the ordinary test suite, and verifies documentation links. The minimum lane
-also compiles and smoke-tests the unpacked Hex package.
+Every pull request and every push to `main` runs without EXLA, Emily, Ortex,
+model downloads, or external services. The current-runtime lane checks
+formatting, warnings, unit/fixture behavior, authoritative manifest integrity,
+static analysis, and documentation. Each compatibility lane compiles with
+warnings as errors, runs the ordinary test suite, and verifies documentation
+links. The minimum lane also compiles and smoke-tests the unpacked Hex package.
 The lockfile hygiene subprocess fetches and evaluates the union of conditional
 optional dependency declarations so Mix can inspect their transitive graphs,
 but it does not compile or execute those adapters.
@@ -127,7 +134,7 @@ this document describes their intended boundaries and local reproduction.
 
 | Workflow | Trigger | Runner | Local command |
 | --- | --- | --- | --- |
-| `ci.yml` | every push and pull request | GitHub-hosted Ubuntu, Elixir 1.17 through 1.20 with representative OTP generations | `mix ci.compatibility` and `mix ci.base` |
+| `ci.yml` | pull requests and pushes to `main` | GitHub-hosted Ubuntu, Elixir 1.17 through 1.20 with representative OTP generations | `mix ci.compatibility` and `mix ci.base` |
 | `optional-compatibility.yml` | weekly and manual | GitHub-hosted Ubuntu, all supported Elixir minors | `mix ci.optional` |
 | `model-validation.yml` Apple | weekly/manual when enabled | `[self-hosted, macOS, ARM64, obscura-metal]` | `mix ci.real_model_smoke` with Emily environment |
 | `model-validation.yml` EXLA | weekly/manual when enabled | `[self-hosted, Linux, X64, obscura-exla]` | `mix ci.real_model_smoke` with EXLA environment |

--- a/eval/fast_profile/retention.exs
+++ b/eval/fast_profile/retention.exs
@@ -4,6 +4,7 @@ defmodule Obscura.FastProfileRetentionProbe do
   @moduledoc false
 
   alias Obscura.Analyzer.Result
+  alias Obscura.Internal.ResultText
   alias Obscura.Recognizer.PatternDefinition
 
   defmodule BorrowingRecognizer do
@@ -1262,10 +1263,10 @@ defmodule Obscura.FastProfileRetentionProbe do
 
   defp inspect_term(value, path, state, sensitive_values) when is_bitstring(value) do
     bytes = byte_size(value)
-    referenced = :binary.referenced_byte_size(value)
+    referenced = ResultText.retained_byte_size(value)
     amplification = referenced / max(bytes, 1)
     text? = List.last(path) == :text
-    borrowed? = referenced > bytes
+    borrowed? = ResultText.borrowed?(value)
 
     sensitive? = Enum.any?(sensitive_values, &contains_sensitive_value?(value, &1))
 

--- a/eval/fast_profile/soak.exs
+++ b/eval/fast_profile/soak.exs
@@ -3,6 +3,8 @@ Mix.Task.run("app.start")
 defmodule Obscura.FastProfileRetentionSoak do
   @moduledoc false
 
+  alias Obscura.Internal.ResultText
+
   @counter_completed 1
   @counter_failures 2
   @counter_controlled_failures 3
@@ -190,7 +192,7 @@ defmodule Obscura.FastProfileRetentionSoak do
            telemetry: false
          ) do
       {:ok, [%{text: value} = result]} when is_binary(value) ->
-        if :binary.referenced_byte_size(value) == byte_size(value) do
+        unless ResultText.borrowed?(value) do
           send(holder, {:hold, result})
           :atomics.add(counters, @counter_held, 1)
           :ok

--- a/lib/obscura/internal/result_text.ex
+++ b/lib/obscura/internal/result_text.ex
@@ -3,7 +3,13 @@ defmodule Obscura.Internal.ResultText do
 
   alias Obscura.Analyzer.Result
 
+  @compile {:inline, retained_byte_size: 1, borrowed?: 1}
   @max_callback_term_depth 256
+  @heap_binary_limit 64
+  @small_heap_binaries_report_bits (
+                                     probe = :binary.copy("ownership-probe")
+                                     :binary.referenced_byte_size(probe) == bit_size(probe)
+                                   )
 
   @spec maybe_materialize(String.t(), keyword()) :: String.t() | nil
   def maybe_materialize(value, opts) when is_binary(value) and is_list(opts) do
@@ -61,6 +67,24 @@ defmodule Obscura.Internal.ResultText do
   def own_term(value), do: value
 
   @doc false
+  @spec retained_byte_size(bitstring()) :: non_neg_integer()
+  def retained_byte_size(value) when is_bitstring(value) do
+    referenced = :binary.referenced_byte_size(value)
+
+    if @small_heap_binaries_report_bits and byte_size(value) <= @heap_binary_limit and
+         referenced == bit_size(value) do
+      byte_size(value)
+    else
+      referenced
+    end
+  end
+
+  @doc false
+  @spec borrowed?(bitstring()) :: boolean()
+  def borrowed?(value) when is_bitstring(value),
+    do: retained_byte_size(value) > byte_size(value)
+
+  @doc false
   @spec safe_callback_term?(term()) :: boolean()
   def safe_callback_term?(value), do: safe_callback_term?(value, nil)
 
@@ -92,7 +116,7 @@ defmodule Obscura.Internal.ResultText do
   end
 
   defp own(value) do
-    if :binary.referenced_byte_size(value) > byte_size(value) do
+    if borrowed?(value) do
       :binary.copy(value)
     else
       value

--- a/mix.exs
+++ b/mix.exs
@@ -185,7 +185,8 @@ defmodule Obscura.MixProject do
       "ci.soak_validate": ["obscura.operational.soak.verify"],
       "ci.diagnostic_validate": ["obscura.operational.diagnostic.verify"],
       "ci.optional": [
-        "test test/obscura/recognizer/deterministic_plus_test.exs test/obscura/recognizer/ner/serving_build_test.exs test/obscura/recognizer/gliner test/obscura/privacy_filter/checkpoint_test.exs test/obscura/privacy_filter/checkpoint"
+        "cmd mix compile --warnings-as-errors",
+        "cmd mix test test/obscura/recognizer/deterministic_plus_test.exs test/obscura/recognizer/ner/serving_build_test.exs test/obscura/recognizer/gliner test/obscura/privacy_filter/checkpoint_test.exs test/obscura/privacy_filter/checkpoint"
       ],
       "ci.real_model_smoke": [
         "cmd mix obscura.eval --compatibility --dataset generated_small --profile balanced --limit 3 --real-model --run-suffix ci_real_model_smoke",
@@ -197,15 +198,15 @@ defmodule Obscura.MixProject do
         "cmd env MIX_ENV=test OBSCURA_REAL_MODEL=1 OBSCURA_REAL_MODEL_BACKEND=emily OBSCURA_GLINER_ORTEX=1 mix deps.unlock --check-unused"
       ],
       "ci.compatibility": [
-        "compile --warnings-as-errors",
-        "test",
+        "cmd mix compile --warnings-as-errors",
+        "cmd mix test",
         "obscura.docs.verify"
       ],
       "ci.base": [
         "deps.check_unused",
         "format --check-formatted",
-        "compile --warnings-as-errors",
-        "test",
+        "cmd mix compile --warnings-as-errors",
+        "cmd mix test",
         "obscura.fixtures",
         "obscura.fixtures --suite accuracy",
         "obscura.eval --compatibility --dataset generated_small --profile fast --limit 5 --run-suffix ci_base",

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Obscura.MixProject do
     [
       app: :obscura,
       version: @version,
-      elixir: "~> 1.20",
+      elixir: "~> 1.17",
       source_url: @source_url,
       homepage_url: @source_url,
       elixirc_options: [no_warn_undefined: optional_modules()],
@@ -37,6 +37,7 @@ defmodule Obscura.MixProject do
       preferred_envs: [
         ci: :test,
         "ci.base": :test,
+        "ci.minimum": :test,
         "ci.optional": :test,
         "ci.real_model_smoke": :test
       ]
@@ -48,15 +49,8 @@ defmodule Obscura.MixProject do
       {:jason, "~> 1.4"},
       {:telemetry, "~> 1.3"},
       {:plug, "~> 1.16"},
-      {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.35", only: [:dev, :test], runtime: false},
-      {:makeup_syntect, "~> 0.1.4", only: [:dev, :test], runtime: false},
       # The Hex constraint lags makeup_syntect's upstream rustler_precompiled 0.9 support.
       {:rustler_precompiled, "~> 0.9", only: [:dev, :test], runtime: false, override: true},
-      {:ex_dna, "~> 1.5", only: [:dev, :test], runtime: false},
-      {:ex_slop, "~> 0.4", only: [:dev, :test], runtime: false},
-      {:credence, "~> 0.6", only: [:dev, :test], runtime: false},
       {:stream_data, "~> 1.4", only: :test},
       {:phoenix, "~> 1.8", only: :test, runtime: false},
       {:nx, "~> 0.12", optional: true},
@@ -66,7 +60,24 @@ defmodule Obscura.MixProject do
     ]
 
     base_deps ++
+      quality_deps() ++
       real_model_deps() ++ mlx_model_deps() ++ gliner_ortex_deps() ++ gliner_tokenizer_deps()
+  end
+
+  defp quality_deps do
+    if System.get_env("OBSCURA_MINIMUM_RUNTIME") == "1" do
+      []
+    else
+      [
+        {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
+        {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
+        {:ex_doc, "~> 0.35", only: [:dev, :test], runtime: false},
+        {:makeup_syntect, "~> 0.1.4", only: [:dev, :test], runtime: false},
+        {:ex_dna, "~> 1.5", only: [:dev, :test], runtime: false},
+        {:ex_slop, "~> 0.4", only: [:dev, :test], runtime: false},
+        {:credence, "~> 0.6", only: [:dev, :test], runtime: false}
+      ]
+    end
   end
 
   defp docs do
@@ -179,6 +190,11 @@ defmodule Obscura.MixProject do
       "deps.check_unused": [
         "cmd env MIX_ENV=test OBSCURA_REAL_MODEL=1 OBSCURA_REAL_MODEL_BACKEND=emily OBSCURA_GLINER_ORTEX=1 mix deps.get --only test",
         "cmd env MIX_ENV=test OBSCURA_REAL_MODEL=1 OBSCURA_REAL_MODEL_BACKEND=emily OBSCURA_GLINER_ORTEX=1 mix deps.unlock --check-unused"
+      ],
+      "ci.minimum": [
+        "compile --warnings-as-errors",
+        "test",
+        "obscura.docs.verify"
       ],
       "ci.base": [
         "deps.check_unused",

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Obscura.MixProject do
       preferred_envs: [
         ci: :test,
         "ci.base": :test,
-        "ci.minimum": :test,
+        "ci.compatibility": :test,
         "ci.optional": :test,
         "ci.real_model_smoke": :test
       ]
@@ -65,7 +65,7 @@ defmodule Obscura.MixProject do
   end
 
   defp quality_deps do
-    if System.get_env("OBSCURA_MINIMUM_RUNTIME") == "1" do
+    if compatibility_runtime?() do
       []
     else
       [
@@ -78,6 +78,11 @@ defmodule Obscura.MixProject do
         {:credence, "~> 0.6", only: [:dev, :test], runtime: false}
       ]
     end
+  end
+
+  defp compatibility_runtime? do
+    System.get_env("OBSCURA_COMPATIBILITY_RUNTIME") == "1" or
+      Version.compare(System.version(), "1.18.0") == :lt
   end
 
   defp docs do
@@ -191,7 +196,7 @@ defmodule Obscura.MixProject do
         "cmd env MIX_ENV=test OBSCURA_REAL_MODEL=1 OBSCURA_REAL_MODEL_BACKEND=emily OBSCURA_GLINER_ORTEX=1 mix deps.get --only test",
         "cmd env MIX_ENV=test OBSCURA_REAL_MODEL=1 OBSCURA_REAL_MODEL_BACKEND=emily OBSCURA_GLINER_ORTEX=1 mix deps.unlock --check-unused"
       ],
-      "ci.minimum": [
+      "ci.compatibility": [
         "compile --warnings-as-errors",
         "test",
         "obscura.docs.verify"

--- a/test/obscura/analyzer/binary_ownership_test.exs
+++ b/test/obscura/analyzer/binary_ownership_test.exs
@@ -3,6 +3,7 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
 
   alias Obscura.Analyzer.Explanation
   alias Obscura.Analyzer.Result
+  alias Obscura.Internal.ResultText
   alias Obscura.Phoenix.Plug, as: ObscuraPlug
   alias Obscura.Recognizer.Address
   alias Obscura.Recognizer.DenyList
@@ -220,6 +221,18 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
     end
   end
 
+  test "retained-size checks distinguish owned small binaries from borrowed large slices" do
+    source = safe_padding(200_000)
+    owned = source |> binary_part(100_000, 15) |> :binary.copy()
+    borrowed = binary_part(source, 100_000, 1_024)
+
+    assert ResultText.retained_byte_size(owned) == byte_size(owned)
+    refute ResultText.borrowed?(owned)
+
+    assert ResultText.retained_byte_size(borrowed) > byte_size(borrowed)
+    assert ResultText.borrowed?(borrowed)
+  end
+
   test "final text does not retain an unrelated large source binary" do
     text = long_url_text()
 
@@ -235,7 +248,7 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
              binary_part(text, result.byte_start, result.byte_end - result.byte_start)
 
     assert byte_size(text) > byte_size(result.text) * 100
-    assert :binary.referenced_byte_size(result.text) == byte_size(result.text)
+    assert ResultText.retained_byte_size(result.text) == byte_size(result.text)
   end
 
   test "analyze_many owns final text independently" do
@@ -249,7 +262,7 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
                telemetry: false
              )
 
-    assert :binary.referenced_byte_size(result.text) == byte_size(result.text)
+    assert ResultText.retained_byte_size(result.text) == byte_size(result.text)
   end
 
   test "custom recognizer borrowed text is normalized to owned final text" do
@@ -265,7 +278,7 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
                telemetry: false
              )
 
-    assert :binary.referenced_byte_size(result.text) == byte_size(result.text)
+    assert ResultText.retained_byte_size(result.text) == byte_size(result.text)
     assert result.metadata.matched_prefix_bytes == 8
   end
 
@@ -310,10 +323,10 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
     assert result.metadata.nested == [%{captured: captured}]
     assert result.explanation.metadata.nested == [%{captured: captured}]
 
-    assert :binary.referenced_byte_size(result.metadata.nested |> hd() |> Map.fetch!(:captured)) ==
+    assert ResultText.retained_byte_size(result.metadata.nested |> hd() |> Map.fetch!(:captured)) ==
              byte_size(captured)
 
-    assert :binary.referenced_byte_size(
+    assert ResultText.retained_byte_size(
              result.explanation.metadata.nested
              |> hd()
              |> Map.fetch!(:captured)
@@ -334,7 +347,7 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
 
       assert result.metadata.phone_e164 == "+442079460958"
 
-      assert :binary.referenced_byte_size(result.metadata.phone_e164) ==
+      assert ResultText.retained_byte_size(result.metadata.phone_e164) ==
                byte_size(result.metadata.phone_e164)
     end
   end
@@ -434,7 +447,7 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
     cloned_borrowed = borrowed_result.metadata.deferred.()
 
     assert cloned_borrowed == binary_part(text, 100_000, 1_024)
-    assert :binary.referenced_byte_size(cloned_borrowed) == byte_size(cloned_borrowed)
+    assert ResultText.retained_byte_size(cloned_borrowed) == byte_size(cloned_borrowed)
   end
 
   test "non-byte-aligned callback metadata does not retain its large source binary" do
@@ -454,7 +467,7 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
 
     assert bit_size(flags) == 8_191
     refute is_binary(flags)
-    assert :binary.referenced_byte_size(flags) == byte_size(flags)
+    assert ResultText.retained_byte_size(flags) == byte_size(flags)
     assert borrowed_binary_paths(result) == []
   end
 
@@ -484,7 +497,7 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
 
       assert escaped == original
       assert byte_size(escaped) == byte_size(text)
-      assert :binary.referenced_byte_size(escaped) == byte_size(escaped)
+      assert ResultText.retained_byte_size(escaped) == byte_size(escaped)
       refute :erts_debug.same(escaped, original)
     end
   end
@@ -545,7 +558,7 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
 
     assert %{__struct__: value} = result.metadata
     assert byte_size(value) == 1_024
-    assert :binary.referenced_byte_size(value) == 1_024
+    assert ResultText.retained_byte_size(value) == 1_024
     assert borrowed_binary_paths(result) == []
   end
 
@@ -754,7 +767,7 @@ defmodule Obscura.Analyzer.BinaryOwnershipTest do
   defp borrowed_binary_paths(term), do: inspect_binaries(term, [], [])
 
   defp inspect_binaries(value, path, acc) when is_binary(value) do
-    if :binary.referenced_byte_size(value) > byte_size(value), do: [path | acc], else: acc
+    if ResultText.borrowed?(value), do: [path | acc], else: acc
   end
 
   defp inspect_binaries(value, path, acc) when is_map(value) do

--- a/test/obscura/recognizer/deterministic_plus_test.exs
+++ b/test/obscura/recognizer/deterministic_plus_test.exs
@@ -2,6 +2,7 @@ defmodule Obscura.Recognizer.DeterministicPlusTest do
   use ExUnit.Case, async: true
 
   alias Obscura.Eval.Profile
+  alias Obscura.Internal.ResultText
 
   test "phone recognizer detects generated short parenthesized phone numbers" do
     assert {:ok, [result]} =
@@ -85,7 +86,7 @@ defmodule Obscura.Recognizer.DeterministicPlusTest do
 
     assert phone.text == nil
     assert phone.metadata.deferred.() == sensitive
-    assert :binary.referenced_byte_size(phone.metadata.deferred.()) == byte_size(sensitive)
+    assert ResultText.retained_byte_size(phone.metadata.deferred.()) == byte_size(sensitive)
   end
 
   test "optional ex_phone_number parser improves Presidio international phone recall" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -26,6 +26,8 @@ exclude =
       else: [gliner_native: true] ++ exclude
   end)
 
+# Dependency compilation must not determine which levels the test suite can capture.
+Logger.configure(level: :debug)
 ExUnit.start(exclude: exclude)
 Code.require_file("support/soak_report_fixture.exs", __DIR__)
 Code.require_file("support/diagnostic_report_fixture.exs", __DIR__)


### PR DESCRIPTION
## Summary

- Lower the minimum supported Elixir version from 1.20 to 1.17.
- Validate Elixir 1.17, 1.18, 1.19, and 1.20 against representative Erlang/OTP generations.
- Keep complete quality gates on the current runtime while compatibility lanes exercise the runtime and test graph.
- Omit current-only development analyzers and Syntect tooling from compatibility dependency graphs.
- Normalize OTP 27 small-heap-binary ownership accounting without hiding borrowed large binaries.
- Smoke-test the unpacked Hex package on the minimum runtime.
- Document the supported matrix and CI boundaries.

## Validation

- `mix ci.compatibility` passed on Elixir 1.17/OTP 27, 1.18/OTP 27, and 1.19/OTP 28.
- `mix ci.base` passed on Elixir 1.20/OTP 29.
- Optional compatibility suites passed across the supported matrix.
- A clean consumer successfully compiled and used the unpacked package on Elixir 1.17/OTP 27.
- Focused binary-ownership tests passed on OTP 27 and OTP 28.
- `actionlint` and `git diff --check` passed.