### PR TITLE
Release Obscura 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 All notable changes to Obscura are documented in this file.
 
-## Unreleased
+## 0.1.3 - 2026-07-31
 
-- Lowered the minimum supported Elixir version from 1.20 to 1.17 and added
-  per-minor Elixir and Erlang/OTP compatibility lanes.
+- Added opt-in privacy-safe Phoenix request logging that consumes a dedicated
+  redacted assign while leaving controller parameters unchanged.
 - Added opt-in privacy-safe Phoenix socket and channel telemetry loggers with
   omission-first payload policies, configured topic patterns and event names,
   bounded `:fast` redaction, and raw-default-logger conflict detection.
+- Lowered the minimum supported Elixir version from 1.20 to 1.17 and added
+  per-minor Elixir and Erlang/OTP compatibility lanes.
 - Bounded realtime parameter analysis, owned allowed event labels, rejected
   unsafe configured labels, and rejected correlation metadata keys containing
   high-confidence PII recognized by the `:fast` profile.
@@ -21,6 +23,8 @@ All notable changes to Obscura are documented in this file.
   its integration options during `init/1`.
 - Added real Phoenix endpoint coverage and a sustained real socket/channel
   redaction regression test.
+- Synchronized operational load-runner workers before starting measurement so
+  scheduler contention cannot produce empty reports.
 
 ## 0.1.2 - 2026-07-24
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Obscura.MixProject do
   use Mix.Project
 
-  @version "0.1.2"
+  @version "0.1.3"
   @source_url "https://github.com/hfiguera/obscura"
   @security_url "#{@source_url}/security/advisories/new"
 

--- a/test/obscura/release_metadata_test.exs
+++ b/test/obscura/release_metadata_test.exs
@@ -8,7 +8,7 @@ defmodule Obscura.ReleaseMetadataTest do
     project = Mix.Project.config()
     package = Keyword.fetch!(project, :package)
 
-    assert project[:version] == "0.1.2"
+    assert project[:version] == "0.1.3"
     assert project[:source_url] == @source_url
     assert project[:homepage_url] == @source_url
     assert package[:links]["GitHub"] == @source_url


### PR DESCRIPTION
## Summary

- release the opt-in privacy-safe Phoenix HTTP, socket, and channel loggers
- support Elixir 1.17 through 1.20 with representative Erlang/OTP compatibility lanes
- include realtime boundary hardening, real Phoenix integration coverage, and synchronized sustained-load measurement

## Validation

- `mix ci` from a clean Git worktree
- `mix hex.build` (checksum `e09768f98c5a45fd41d4bc10b111d0fe0f8f7764de27f6b31a4fd7baf2db58d9`)
- unpacked Hex package validation
- clean production consumer smoke test for `:fast` and all Phoenix logger modules

Local training assets, caches, blog drafts, and virtual environments are excluded from the package.