### PR TITLE
Fix repository links in efficient profile ExDoc guides

### DIFF
--- a/docs/efficient.md
+++ b/docs/efficient.md
@@ -125,12 +125,12 @@ not a new grant covering upstream training corpora. Obscura distributes its
 MIT native implementation and release executables; model weights are fetched
 from Explosion and exported locally, outside the Hex package and native release.
 See [asset licensing](model-asset-licensing.md) and
-[native third-party notices](../native/spacy_cpu/THIRD_PARTY_NOTICES.md).
+[native third-party notices](https://github.com/hfiguera/obscura/blob/main/native/spacy_cpu/THIRD_PARTY_NOTICES.md).
 
 The versioned asset manifest is `priv/obscura/efficient-assets.json`.
 `native/spacy_cpu/export-requirements.txt` freezes the independent export
 dependencies with hashes. Rust 1.90.0, Cargo.lock, and the digest/snapshot-pinned
-[Linux recipe](../native/spacy_cpu/release/Dockerfile) make native builds
+[Linux recipe](https://github.com/hfiguera/obscura/blob/main/native/spacy_cpu/release/Dockerfile) make native builds
 repeatable. macOS additionally depends on its recorded Apple SDK and PCRE2
 installation; the build normalizes the content-derived Mach-O UUID and ad-hoc
 signature. Reproducibility means identical bytes for the recorded build
@@ -138,7 +138,7 @@ environment, not identical output across different SDKs or library toolchains.
 
 ## Evidence and limits
 
-The [release evaluation](../eval/efficient/README.md) uses separate development
+The [release evaluation](https://github.com/hfiguera/obscura/blob/main/eval/efficient/README.md) uses separate development
 and untouched test sets. On 5,000 synthetic application-like test documents,
 exact-span F1 is 0.6654 for `:efficient`, 0.6406 for the original native profile,
 0.6351 for `:fast`, and 0.6102 for pinned Presidio. Efficient has fewer false

--- a/docs/spacy-cpu.md
+++ b/docs/spacy-cpu.md
@@ -163,10 +163,10 @@ executable and pinned weights. Real-model tests skip when assets/platform are
 unavailable. No authoritative accuracy profile is promoted by these checks.
 
 For reproducible Docker Desktop checks of both Linux architectures, see
-[Linux validation](../eval/spacy_native/linux/README.md). The lane requires the
+[Linux validation](https://github.com/hfiguera/obscura/blob/main/eval/spacy_native/linux/README.md). The lane requires the
 real assets, tests the public profile and worker lifecycle, and compares all
 2,648 selected documents to the pinned native baseline twice with networking
-disabled; see the [recorded Linux results](../eval/spacy_native/results/LINUX.md).
+disabled; see the [recorded Linux results](https://github.com/hfiguera/obscura/blob/main/eval/spacy_native/results/LINUX.md).
 x86-64 runs under emulation on an Apple Silicon host, so its timing
 does not predict performance on physical x86-64 hardware.
 


### PR DESCRIPTION
The efficient and experimental spaCy CPU guides link to evaluation reports, native dependency notices, and the Linux build recipe that are not included as ExDoc pages. Relative links can produce missing-file warnings or resolve to the wrong README page in generated documentation.

Replace those five links with explicit GitHub URLs so the guides work both in the repository and in generated ExDoc. This changes only two Markdown files.

Validation: `mix docs` completes without warnings, the five generated HTML links point to their intended repository files, and `mix obscura.docs.verify docs/efficient.md docs/spacy-cpu.md` passes.
