### PR TITLE
Release Obscura 0.2.0

### DIFF
--- a/.github/workflows/efficient.yml
+++ b/.github/workflows/efficient.yml
@@ -3,14 +3,19 @@ name: Efficient Linux release validation
 on:
   pull_request:
     paths:
+      - 'mix.exs'
+      - 'mix.lock'
       - 'lib/**'
       - 'native/spacy_cpu/**'
       - 'priv/obscura/**'
       - 'test/obscura/spacy/**'
+      - 'test/obscura/release_metadata_test.exs'
+      - 'test/mix/tasks/obscura.efficient.install_test.exs'
       - 'eval/efficient/**'
+      - 'scripts/efficient/**'
       - '.github/workflows/efficient.yml'
   push:
-    branches: [main, efficient-cpu-profile]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Obscura are documented in this file.
 
-## 0.2.0 - release candidate
+## 0.2.0 - 2026-09-05
 
 - Added the stable `:efficient` CPU profile with deterministic recognition and
   native spaCy person/location NER on Apple Silicon macOS and glibc Linux.
@@ -13,6 +13,8 @@ All notable changes to Obscura are documented in this file.
 - Added untouched application-like accuracy evaluation, sustained workload
   validation for 1–4 workers, and native release compatibility checks.
 - Preserved worker capacity when a caller abandons an unused reservation.
+- Updated Nx, Bumblebee, Phoenix, and supporting dependencies while preserving
+  the Elixir 1.17 minimum and dependency-light core.
 
 ## 0.1.3 - 2026-07-31
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ open-class entities.
 
 ### Public API Changes
 
-The stable `0.1.x` surface is defined by
+The stable `0.2.x` surface is defined by
 `priv/obscura/public_api.exs` and documented in
 `docs/public-api-stability.md`. A change to stable return shapes, error codes,
 defaults, callbacks, profile semantics, or accepted options requires contract

--- a/README.md
+++ b/README.md
@@ -23,23 +23,27 @@ recognition. Obscura does not require a hosted recognition service.
 Obscura supports Elixir 1.17 and later. CI validates every supported Elixir
 minor from 1.17 through 1.20 against a representative Erlang/OTP generation.
 
-Add Obscura to an Elixir project:
+Install the 0.2.0 GitHub release in an Elixir project:
 
 ```elixir
 def deps do
   [
-    {:obscura, "~> 0.1.0"}
+    {:obscura, github: "hfiguera/obscura", tag: "v0.2.0"}
   ]
 end
 ```
+
+This release is available through GitHub. Hex publication is separate; the
+existing `{:obscura, "~> 0.1.0"}` Hex dependency does not include `:efficient`.
 
 The base installation supports the `:fast` profile without model assets or
 accelerator dependencies. See the
 [optional dependencies and assets guide](docs/optional-dependencies-and-assets.md)
 before enabling a model-backed profile.
 
-The upcoming `:efficient` CPU profile (unpublished on this branch) adds English person/location NER with verified
-local assets. See its [installation and public contract](docs/efficient.md).
+The stable `:efficient` CPU profile adds English person/location NER with
+verified local assets on Apple Silicon macOS and glibc Linux x86-64/ARM64.
+See its [installation and public contract](docs/efficient.md).
 
 ## Analyze
 
@@ -431,7 +435,7 @@ historical evidence unless promoted by the authoritative manifest.
 
 ## Maturity
 
-Obscura `0.1.x` is an early release suitable for integration and controlled
+Obscura `0.2.x` is an early release suitable for integration and controlled
 deployment when its measured scope and residual risks fit the application. It
 is not a compliance guarantee, a complete Presidio replacement, or evidence of
 universal production readiness.
@@ -479,15 +483,16 @@ datasets in a report.
 
 ## Compatibility
 
-Obscura defines compatibility guarantees for its stable `0.1.x` surface. See
+Obscura defines compatibility guarantees for its stable `0.2.x` surface. See
 the [public API stability policy](docs/public-api-stability.md) for the complete
 classification of stable, experimental, and internal modules, along with option
 schemas, struct guarantees, and the deprecation policy.
 
-| Surface | `0.1.x` status |
+| Surface | `0.2.x` status |
 | --- | --- |
 | Core text, structured, vault, LLM, Logger, Plug, and operator APIs | Stable |
 | `:fast` alias | Stable name and dependency-light contract |
+| `:efficient` alias | Stable native CPU contract for English person/location NER on Apple Silicon macOS and glibc Linux x86-64/ARM64 |
 | `:balanced` and `:accurate` aliases | Stable implementation contracts; commercial use of their OntoNotes-trained TNER checkpoint requires LDC for-profit membership |
 | Experimental profiles and low-level model adapters | Controlled evaluation without compatibility guarantees |
 | Evaluation, fixture, engine, registry, and model-math modules | Internal |

--- a/docs/efficient.md
+++ b/docs/efficient.md
@@ -1,9 +1,6 @@
 # Efficient CPU profile
 
-This is the unpublished `:efficient` release candidate for the 0.2 line.
-Installation from public release URLs becomes available only after publication.
-For this checkout, use `--from-source --allow-download` or the verified local
-binaries recorded in the asset manifest. It combines
+The stable `:efficient` profile, introduced in Obscura 0.2.0, combines
 Obscura's deterministic recognizers with a native port of spaCy's pinned
 `en_core_web_lg` 3.8.0 NER model and the frozen `efficient_v1` boundary policy.
 Use it when CPU cost and memory matter and English person/location recognition
@@ -20,6 +17,11 @@ The experimental `:spacy_cpu` alias remains available with its original span
 policy. It does not silently acquire the new form-field boundary rules.
 
 ## Install once, prepare at startup
+
+Install Obscura from the `v0.2.0` GitHub tag as shown in the
+[installation guide](../README.md#installation). Native binaries are attached
+to that GitHub release; model weights are downloaded from Explosion and
+exported locally. Hex publication is separate.
 
 Install the platform libraries: `brew install pcre2` on Apple Silicon macOS,
 or `apt-get install curl libopenblas0-pthread libpcre2-8-0` on supported Debian/Ubuntu

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -4,7 +4,7 @@ Obscura is an early-release library. Its stable profiles have governed contracts
 and current benchmark evidence, but the project does not yet claim universal
 production readiness, regulatory compliance, or complete Presidio parity.
 
-The `0.1.x` compatibility promise applies only to modules and functions listed
+The `0.2.x` compatibility promise applies only to modules and functions listed
 in `docs/public-api-stability.md`. Low-level model adapters, evaluation
 tooling, and internal implementation modules can change independently of that
 surface.

--- a/docs/model-backed-recognition.md
+++ b/docs/model-backed-recognition.md
@@ -81,7 +81,7 @@ Obscura.analyze("Rachel works at Google in Paris.",
 ```
 
 The low-level recognizer, serving, model registry, and model-specific options
-are experimental in `0.1.x`. Public profile names and their documented runtime
+are experimental in `0.2.x`. Public profile names and their documented runtime
 contracts have the stability described in `public-api-stability.md`.
 
 ## Optional Backend Selection
@@ -240,7 +240,7 @@ across recognizers.
 
 Obscura contains experimental adapters for GLiNER through Ortex or native Nx,
 generic ONNX token classification, and native Privacy Filter checkpoints.
-They are useful for controlled evaluation but are outside the stable `0.1.x`
+They are useful for controlled evaluation but are outside the stable `0.2.x`
 compatibility promise.
 
 Experimental adapters require explicit local assets and dependencies. They do

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -162,7 +162,7 @@ collections are errors, including configurations for entities which do not
 appear in the current input.
 
 Operator types, keys, defaults, preflight behavior, and stable error codes are
-part of the `0.1.x` contract. Human-readable messages and additive metadata are
+part of the `0.2.x` contract. Human-readable messages and additive metadata are
 not. See `docs/public-api-stability.md`.
 
 Default `Inspect` implementations for anonymizer result and item structs hide

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -310,7 +310,7 @@ operational conclusions, `docs/optional-dependencies-and-assets.md` for setup
 details, and `docs/known-limitations.md` for residual deployment risks.
 
 The stable `:fast`, `:efficient`, `:balanced`, and `:accurate` aliases are covered by the
-`0.1.x` compatibility policy.
+`0.2.x` compatibility policy.
 Experimental aliases, low-level model adapters, serving structs, tensor
 layouts, and model-specific tuning options may change independently. See
 `docs/public-api-stability.md`.

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -2,7 +2,7 @@
 
 ## Purpose And Status
 
-This threat model defines Obscura's security boundary for the `0.1.x`
+This threat model defines Obscura's security boundary for the `0.2.x`
 early-release line. It covers raw PII lifetime, anonymization, reversible vaults,
 model execution, observability, callbacks, structured data, command output,
 and benchmark reports.

--- a/docs/vaults.md
+++ b/docs/vaults.md
@@ -52,7 +52,7 @@ ordinary processes cannot read those tables directly; access goes through the
 vault process. This is process isolation, not encryption. A process with VM
 administration capabilities can still inspect process state or memory.
 
-The legacy `table:` startup option remains accepted as an atom for `0.1.x`
+The legacy `table:` startup option remains accepted as an atom for `0.2.x`
 configuration compatibility, but it no longer creates or names an ETS table.
 Code which accessed those tables directly must migrate to the
 `Obscura.Vault` API. This intentional behavior change closes an unauthorized

--- a/eval/efficient/README.md
+++ b/eval/efficient/README.md
@@ -145,8 +145,9 @@ deployment's workload and contention.
 
 [Build evidence](results/builds.json) records byte-identical independent native
 rebuilds on all three targets, matching fresh model exports on macOS and Linux,
-and a clean packaged consumer on Elixir 1.17.3 / OTP 27 with four native workers
-and no Python, Nx, or Bumblebee. The full macOS suite passed 864 checks with
+and clean packaged consumers for both the candidate and final 0.2.0 package on
+Elixir 1.17.3 / OTP 27 with four native workers and no Python, Nx, or Bumblebee.
+The final package passed with networking disabled. The full macOS suite passed 864 checks with
 14 optional exclusions; native Linux compatibility passed 183 tests on each
 architecture. The final installer/native tests passed another 34 checks.
 
@@ -157,9 +158,12 @@ the frozen policy or evaluation selection.
 
 Run `python3 scripts/efficient/verify_candidate.py` to verify the local evidence
 against the current sources and asset manifest. This checks evidence only and
-never publishes anything. The candidate remains **unpublished** at the user's
-request. The added hosted Linux CI workflow has not run and remains required
-before a future release. Linux x86-64 and ARM64 servers are the production
-targets. Apple Silicon macOS results validate the local development environment;
+never publishes anything. Hosted [Linux release validation](https://github.com/hfiguera/obscura/actions/runs/33981834669)
+and [dependency-light CI](https://github.com/hfiguera/obscura/actions/runs/33981834653)
+passed on `7ac965dbb50380ed3fa4b0e51e1e1c843f5612e6` before release preparation.
+The release PR reruns these checks after finalizing the 0.2.0 metadata. Native
+assets are distributed with the `v0.2.0` GitHub release; Hex publication is a
+separate step. Linux x86-64 and ARM64 servers are the production targets.
+Apple Silicon macOS results validate the local development environment;
 older macOS compatibility is outside the release requirements. All recorded
 measurements and evaluation thresholds are unchanged by this platform scope.

--- a/eval/efficient/results/builds.json
+++ b/eval/efficient/results/builds.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "status": "unpublished_candidate",
+  "status": "validated_for_release",
   "native": {
     "aarch64-apple-darwin": {
       "sha256": "a4c6202e03416471a23ff28c83b08d32d074fd9f238a68601b5feac1eafb3eda",
@@ -73,12 +73,47 @@
     "macos_excluded": 14,
     "linux_arm64_tests_passed": 183,
     "physical_linux_x86_64_tests_passed": 183,
-    "hosted_release_ci_run": false,
+    "hosted_release_ci_run": true,
     "release_ci_targets": [
       "x86_64-unknown-linux-gnu",
       "aarch64-unknown-linux-gnu"
     ],
     "macos_validation_scope": "local_development",
-    "final_installer_and_native_tests_passed": 34
+    "final_installer_and_native_tests_passed": 34,
+    "hosted_ci_evidence": [
+      {
+        "workflow": "Efficient Linux release validation",
+        "conclusion": "success",
+        "head_sha": "7ac965dbb50380ed3fa4b0e51e1e1c843f5612e6",
+        "url": "https://github.com/hfiguera/obscura/actions/runs/33981834669"
+      },
+      {
+        "workflow": "Dependency-light CI",
+        "conclusion": "success",
+        "head_sha": "7ac965dbb50380ed3fa4b0e51e1e1c843f5612e6",
+        "url": "https://github.com/hfiguera/obscura/actions/runs/33981834653"
+      }
+    ]
+  },
+  "release_package_consumer": {
+    "passed": true,
+    "elixir": "1.17.3",
+    "otp": "27",
+    "architecture": "Linux ARM64",
+    "environment": "prod",
+    "workers": 4,
+    "nx_loaded": false,
+    "bumblebee_loaded": false,
+    "python_installed": false,
+    "artifact_sha256": "3fd3f5f9ec6522c8738a1d6a4fa2d2b3590df78d4bb2963f976858e51c4db01e",
+    "package_version": "0.2.0",
+    "network": "disabled",
+    "verification": [
+      "supervised preparation with four workers",
+      "Unicode person, location, and email recognition",
+      "redaction",
+      "batch analysis",
+      "controlled error after shutdown"
+    ]
   }
 }

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Obscura.MixProject do
   use Mix.Project
 
-  @version "0.2.0-dev"
+  @version "0.2.0"
   @source_url "https://github.com/hfiguera/obscura"
   @security_url "#{@source_url}/security/advisories/new"
 

--- a/scripts/efficient/verify_candidate.py
+++ b/scripts/efficient/verify_candidate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify local evidence for the unpublished efficient candidate. Never publishes."""
+"""Verify recorded efficient release evidence against local sources. Never publishes."""
 import hashlib
 import json
 from pathlib import Path
@@ -61,7 +61,14 @@ def main():
     assert builds["physical_linux"]["virtualization"] == "none"
     assert builds["package_consumer"]["passed"]
     assert builds["package_consumer"]["elixir"] == "1.17.3"
-    print("Local efficient candidate gates passed. Unpublished; hosted Linux release CI remains required before publication.")
+    assert builds["release_package_consumer"]["passed"]
+    assert builds["release_package_consumer"]["package_version"] == "0.2.0"
+    assert builds["compatibility"]["hosted_release_ci_run"]
+    for run in builds["compatibility"]["hosted_ci_evidence"]:
+        assert run["conclusion"] == "success"
+        assert len(run["head_sha"]) == 40
+        assert run["url"].startswith("https://github.com/hfiguera/obscura/actions/runs/")
+    print("Efficient release evidence verified. Hosted CI results are recorded evidence; run release PR checks before publication.")
 
 
 if __name__ == "__main__":

--- a/test/obscura/release_metadata_test.exs
+++ b/test/obscura/release_metadata_test.exs
@@ -8,7 +8,8 @@ defmodule Obscura.ReleaseMetadataTest do
     project = Mix.Project.config()
     package = Keyword.fetch!(project, :package)
 
-    assert project[:version] == "0.2.0-dev"
+    assert project[:version] == "0.2.0"
+    assert project[:docs][:source_ref] == "v0.2.0"
     assert project[:source_url] == @source_url
     assert project[:homepage_url] == @source_url
     assert package[:links]["GitHub"] == @source_url


### PR DESCRIPTION
Prepare Obscura 0.2.0 for its GitHub release, making the stable `:efficient` native CPU profile available on Apple Silicon macOS and glibc Linux x86-64/ARM64.

Set the final package version and ExDoc source tag, date the changelog, update the current 0.2.x contract documentation, and replace stale candidate/CI status with recorded validation. Installation uses the GitHub tag while Hex publication remains separate. Extend native CI triggers to cover release metadata and installer changes.

Validation:

- Core suite: 858 passed, 6 native tests skipped, 14 unrelated optional exclusions; native/installer suite separately passed all 34 tests with real assets.
- Formatting, compilation with warnings as errors, and 114 Markdown link checks passed. ExDoc generated without warnings and points to `v0.2.0`.
- Final 0.2.0 package built and passed a network-disabled Linux ARM64 consumer on Elixir 1.17.3 / OTP 27 with four workers and no Python, Nx, or Bumblebee.
- All three release binaries match the pinned manifest and independent rebuild evidence. Native notices and checksums verified; workload and accuracy evidence still matches unchanged runtime sources.

After green release PR CI and squash merge, tag the merged commit `v0.2.0` and attach the three native executables, license notices, and SHA256SUMS to the GitHub release. Model weights are provisioned from Explosion rather than uploaded with these assets. This PR does not publish a Hex package or HexDocs.
